### PR TITLE
Expose 22 missing monarchmoney library features as MCP tools

### DIFF
--- a/.claude/skills/test-monarch-mcp/SKILL.md
+++ b/.claude/skills/test-monarch-mcp/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: test-monarch-mcp
-description: Systematically test all 16 Monarch Money MCP tools — happy paths, edge cases, and error handling. Account-agnostic (discovers IDs at runtime) and self-cleaning (deletes everything it creates).
+description: Systematically test all 39 Monarch Money MCP tools — happy paths, edge cases, and error handling. Account-agnostic (discovers IDs at runtime) and self-cleaning (deletes everything it creates).
 user_invocable: true
 ---
 
 # Test Monarch MCP Skill
 
 You are executing a comprehensive test suite for the Monarch Money MCP server.
-Run all 77 tests across 7 phases, track results, and clean up after yourself.
+Run all 127 tests across 12 phases, track results, and clean up after yourself.
 
 ---
 
@@ -51,11 +51,13 @@ The state file is `mcp-test-state.json` in the project root (`C:\dev\monarch-mcp
   },
   "created_resources": {
     "transactions": [],
-    "tags": []
+    "tags": [],
+    "categories": [],
+    "accounts": []
   },
   "results": {},
   "summary": {
-    "total": 77,
+    "total": 127,
     "passed": 0,
     "failed": 0,
     "skipped": 0
@@ -179,6 +181,60 @@ After completing all tests, update state file: `last_completed_phase: 7`, add re
 
 ---
 
+## Phase 8 — Categories (10 tests)
+
+Load and follow: `references/categories.md`
+
+Tests `get_transaction_categories`, `get_transaction_category_groups`, `create_transaction_category`, and `delete_transaction_category`.
+
+**Important:** Track every created category ID in `created_resources.categories` immediately after creation.
+
+After completing all tests, update state file: `last_completed_phase: 8`, add results.
+
+---
+
+## Phase 9 — Transaction Details & Splits (8 tests)
+
+Load and follow: `references/transaction-details-and-splits.md`
+
+Tests `get_transaction_details`, `get_transaction_splits`, and `update_transaction_splits`.
+
+After completing all tests, update state file: `last_completed_phase: 9`, add results.
+
+---
+
+## Phase 10 — Read-Only Tools (12 tests)
+
+Load and follow: `references/read-only-tools.md`
+
+Tests `get_transactions_summary`, `get_subscription_details`, `get_institutions`, `get_cashflow_summary`, `get_recurring_transactions`, and `set_budget_amount`.
+
+After completing all tests, update state file: `last_completed_phase: 10`, add results.
+
+---
+
+## Phase 11 — Account Management (10 tests)
+
+Load and follow: `references/account-management.md`
+
+Tests `create_manual_account`, `update_account`, `delete_account`, `get_account_type_options`, `get_account_history`, `get_recent_account_balances`, `get_account_snapshots_by_type`, `get_aggregate_snapshots`.
+
+**Important:** Track every created account ID in `created_resources.accounts` immediately after creation.
+
+After completing all tests, update state file: `last_completed_phase: 11`, add results.
+
+---
+
+## Phase 12 — Analytics Tools (5 tests)
+
+Load and follow: `references/analytics-tools.md`
+
+Tests `get_credit_history`, advanced transaction search filters.
+
+After completing all tests, update state file: `last_completed_phase: 12`, add results.
+
+---
+
 ## Cleanup Phase
 
 **This phase ALWAYS runs**, even if earlier phases failed or were skipped.
@@ -222,6 +278,22 @@ Log success/failure for each. Continue on failure.
 For each ID in `created_resources.tags`:
 ```
 delete_transaction_tag(tag_id = {id})
+```
+Log success/failure for each. Continue on failure.
+
+### Step 4b: Delete Created Categories
+
+For each ID in `created_resources.categories`:
+```
+delete_transaction_category(category_id = {id})
+```
+Log success/failure for each. Continue on failure.
+
+### Step 4c: Delete Created Accounts
+
+For each ID in `created_resources.accounts`:
+```
+delete_account(account_id = {id})
 ```
 Log success/failure for each. Continue on failure.
 

--- a/.claude/skills/test-monarch-mcp/SKILL.md
+++ b/.claude/skills/test-monarch-mcp/SKILL.md
@@ -141,7 +141,7 @@ After completing all tests, update state file: `last_completed_phase: 3`, add re
 
 ---
 
-## Phase 4 — Budgets & Cashflow (12 tests)
+## Phase 4 — Budgets, Cashflow & Budget Amounts (15 tests)
 
 Load and follow: `references/budgets-and-cashflow.md`
 
@@ -203,11 +203,11 @@ After completing all tests, update state file: `last_completed_phase: 9`, add re
 
 ---
 
-## Phase 10 — Read-Only Tools (12 tests)
+## Phase 10 — Read-Only Tools (9 tests)
 
 Load and follow: `references/read-only-tools.md`
 
-Tests `get_transactions_summary`, `get_subscription_details`, `get_institutions`, `get_cashflow_summary`, `get_recurring_transactions`, and `set_budget_amount`.
+Tests `get_transactions_summary`, `get_subscription_details`, `get_institutions`, `get_cashflow_summary`, and `get_recurring_transactions`.
 
 After completing all tests, update state file: `last_completed_phase: 10`, add results.
 

--- a/.claude/skills/test-monarch-mcp/SKILL.md
+++ b/.claude/skills/test-monarch-mcp/SKILL.md
@@ -83,6 +83,30 @@ The state file is `mcp-test-state.json` in the project root (`C:\dev\monarch-mcp
 
 ---
 
+## Pre-flight Warning
+
+Before starting any test work (including Phase 0), display this warning and **STOP and wait for explicit user approval**:
+
+---
+
+**WARNING: This test suite operates on your live Monarch Money account.**
+
+- It **creates and deletes** transactions, tags, categories, and accounts.
+- It **temporarily modifies** an existing transaction (then reverts it).
+- The test is designed to clean up everything it creates, but **if something goes wrong** (network error, timeout, context limit), **cleanup may be incomplete** and unwanted changes could remain in your account.
+- All test-created data is prefixed with `MCP-Test-` for easy manual identification.
+- If the session is interrupted, you can **resume where you left off** by invoking this skill again — it will detect the saved progress and offer to continue.
+
+**Do you want to continue?**
+
+---
+
+Do NOT proceed until the user explicitly confirms. If the user declines, stop immediately.
+
+This warning applies to **fresh runs only**. When resuming an in-progress run or performing cleanup-only, skip this warning (the user already accepted the risk).
+
+---
+
 ## Phase 0 — Discovery
 
 This phase runs first. No reference file — execute inline.

--- a/.claude/skills/test-monarch-mcp/references/account-management.md
+++ b/.claude/skills/test-monarch-mcp/references/account-management.md
@@ -1,0 +1,41 @@
+# Phase 11 — Account Management (10 tests)
+
+## 11.1 — get_account_type_options: returns valid types
+Call `get_account_type_options()`.
+**Expected:** JSON with account type options. Record a valid `account_type` and `account_sub_type` for later use.
+
+## 11.2 — create_manual_account: happy path
+Using types from 11.1, call `create_manual_account(account_name="MCP-Test-Account", account_type={type}, account_sub_type={sub_type}, is_in_net_worth=False, account_balance=0)`.
+**Expected:** Success. Record the account ID in `created_resources.accounts`.
+
+## 11.3 — update_account: rename
+Call `update_account(account_id={created_account_id}, account_name="MCP-Test-Renamed")`.
+**Expected:** Success.
+
+## 11.4 — update_account: update balance
+Call `update_account(account_id={created_account_id}, account_balance=1000.0)`.
+**Expected:** Success.
+
+## 11.5 — update_account: toggle net worth
+Call `update_account(account_id={created_account_id}, include_in_net_worth=True)`.
+**Expected:** Success.
+
+## 11.6 — get_account_history: for created account
+Call `get_account_history(account_id={created_account_id})`.
+**Expected:** JSON response (may have limited history for a brand new account).
+
+## 11.7 — get_recent_account_balances: no date
+Call `get_recent_account_balances()`.
+**Expected:** JSON with balance data.
+
+## 11.8 — get_account_snapshots_by_type: month
+Call `get_account_snapshots_by_type(start_date="2025-01-01", timeframe="month")`.
+**Expected:** JSON with snapshot data.
+
+## 11.9 — get_account_snapshots_by_type: invalid timeframe
+Call `get_account_snapshots_by_type(start_date="2025-01-01", timeframe="week")`.
+**Expected:** JSON with `error` key about invalid timeframe.
+
+## 11.10 — get_aggregate_snapshots: no params
+Call `get_aggregate_snapshots()`.
+**Expected:** JSON with aggregate snapshot data.

--- a/.claude/skills/test-monarch-mcp/references/analytics-tools.md
+++ b/.claude/skills/test-monarch-mcp/references/analytics-tools.md
@@ -1,0 +1,21 @@
+# Phase 12 — Analytics Tools (5 tests)
+
+## 12.1 — get_credit_history: returns data or empty
+Call `get_credit_history()`.
+**Expected:** JSON response. May have empty `creditHistory` list if not configured, but should not error.
+
+## 12.2 — get_transactions: search filter
+Call `get_transactions(limit=5, search="test")`.
+**Expected:** JSON array (may be empty). Verify the call succeeds without error.
+
+## 12.3 — get_transactions: category_ids filter
+Call `get_transactions(limit=5, category_ids=["{valid_category_id}"])`.
+**Expected:** JSON array. All returned transactions should have the specified category.
+
+## 12.4 — get_transactions: boolean filters
+Call `get_transactions(limit=5, is_recurring=True)`.
+**Expected:** JSON array. If any results, they should have `is_recurring: true`.
+
+## 12.5 — get_transactions: account_id + account_ids conflict
+Call `get_transactions(account_id="acc-1", account_ids=["acc-2"])`.
+**Expected:** JSON with `error` key about not using both parameters.

--- a/.claude/skills/test-monarch-mcp/references/budgets-and-cashflow.md
+++ b/.claude/skills/test-monarch-mcp/references/budgets-and-cashflow.md
@@ -1,4 +1,4 @@
-# Phase 4 — Budgets & Cashflow (12 tests)
+# Phase 4 — Budgets, Cashflow & Budget Amounts (15 tests)
 
 ---
 
@@ -177,5 +177,52 @@ get_cashflow(start_date = "2030-01-01", end_date = "2030-12-31")
 **Expected:** A dict with cashflow data, likely showing zero sums for income and expenses.
 
 **Validation:** Response is a dict/structured object (not an error string). No crash.
+
+**Cleanup:** None.
+
+---
+
+## Test 4.13 — set_budget_amount: with category_id
+
+Pick a `category_id` from discovery (or use `{valid_category_id}`).
+
+**Tool call:**
+```
+set_budget_amount(amount=500.0, category_id={valid_category_id})
+```
+
+**Expected:** Success response.
+
+**Validation:** Response is a dict/structured object (not an error string).
+
+**Cleanup:** None.
+
+---
+
+## Test 4.14 — set_budget_amount: both IDs -> error
+
+**Tool call:**
+```
+set_budget_amount(amount=100.0, category_id="cat-1", category_group_id="grp-1")
+```
+
+**Expected:** JSON with `error` key about providing exactly one.
+
+**Validation:** Response contains "error" key with "exactly one" (case-insensitive).
+
+**Cleanup:** None.
+
+---
+
+## Test 4.15 — set_budget_amount: neither ID -> error
+
+**Tool call:**
+```
+set_budget_amount(amount=100.0)
+```
+
+**Expected:** JSON with `error` key about providing exactly one.
+
+**Validation:** Response contains "error" key with "exactly one" (case-insensitive).
 
 **Cleanup:** None.

--- a/.claude/skills/test-monarch-mcp/references/categories.md
+++ b/.claude/skills/test-monarch-mcp/references/categories.md
@@ -1,0 +1,40 @@
+# Phase 8 — Categories (10 tests)
+
+## 8.1 — get_transaction_categories: returns categories
+Call `get_transaction_categories()`.
+**Expected:** JSON with a `categories` key containing a non-empty list. Each category has `id`, `name`, and `group`.
+
+## 8.2 — get_transaction_category_groups: returns groups
+Call `get_transaction_category_groups()`.
+**Expected:** JSON with a `categoryGroups` key containing a non-empty list. Each group has `id`, `name`, `type`.
+
+## 8.3 — get_transaction_category_groups: groups have type field
+From the result of 8.2, verify at least one group has `type` equal to `"expense"` or `"income"`.
+
+## 8.4 — create_transaction_category: happy path
+Pick a `group_id` from a group with `type: "expense"` discovered in 8.2.
+Call `create_transaction_category(group_id={group_id}, name="MCP-Test-Category")`.
+**Expected:** JSON response with the created category. Record the ID in `created_resources.categories`.
+
+## 8.5 — create_transaction_category: custom icon
+Call `create_transaction_category(group_id={group_id}, name="MCP-Test-Icon-Cat", icon="🎮")`.
+**Expected:** Success. Record the ID.
+
+## 8.6 — create_transaction_category: with rollover
+Call `create_transaction_category(group_id={group_id}, name="MCP-Test-Rollover", rollover_enabled=True, rollover_start_month="2025-01-01")`.
+**Expected:** Success. Record the ID.
+
+## 8.7 — create_transaction_category: invalid group_id
+Call `create_transaction_category(group_id="invalid-group", name="MCP-Test-Bad")`.
+**Expected:** Error response.
+
+## 8.8 — get_transaction_categories: created categories visible
+Call `get_transaction_categories()` and verify the categories created in 8.4–8.6 appear in the list.
+
+## 8.9 — delete_transaction_category: happy path
+Call `delete_transaction_category(category_id={id from 8.5})`.
+**Expected:** JSON with `deleted: true`. Remove from `created_resources.categories`.
+
+## 8.10 — delete_transaction_category: invalid ID
+Call `delete_transaction_category(category_id="invalid-cat-id")`.
+**Expected:** Error response.

--- a/.claude/skills/test-monarch-mcp/references/read-only-tools.md
+++ b/.claude/skills/test-monarch-mcp/references/read-only-tools.md
@@ -1,4 +1,4 @@
-# Phase 10 — Read-Only Tools (12 tests)
+# Phase 10 — Read-Only Tools (9 tests)
 
 ## 10.1 — get_transactions_summary: returns aggregate stats
 Call `get_transactions_summary()`.
@@ -36,15 +36,3 @@ Call `get_recurring_transactions(start_date="2025-01-01", end_date="2025-12-31")
 Call `get_recurring_transactions(end_date="2025-12-31")`.
 **Expected:** JSON with `error` key.
 
-## 10.10 — set_budget_amount: with category_id
-Pick a `category_id` from the categories discovered in Phase 8 (or use `{valid_category_id}`).
-Call `set_budget_amount(amount=500.0, category_id={valid_category_id})`.
-**Expected:** Success response.
-
-## 10.11 — set_budget_amount: both IDs -> error
-Call `set_budget_amount(amount=100.0, category_id="cat-1", category_group_id="grp-1")`.
-**Expected:** JSON with `error` key about providing exactly one.
-
-## 10.12 — set_budget_amount: neither ID -> error
-Call `set_budget_amount(amount=100.0)`.
-**Expected:** JSON with `error` key about providing exactly one.

--- a/.claude/skills/test-monarch-mcp/references/read-only-tools.md
+++ b/.claude/skills/test-monarch-mcp/references/read-only-tools.md
@@ -1,0 +1,50 @@
+# Phase 10 — Read-Only Tools (12 tests)
+
+## 10.1 — get_transactions_summary: returns aggregate stats
+Call `get_transactions_summary()`.
+**Expected:** JSON response with summary data (count, sum, or similar aggregation fields).
+
+## 10.2 — get_subscription_details: returns subscription info
+Call `get_subscription_details()`.
+**Expected:** JSON with subscription details including at least one of: `id`, `paymentSource`, `hasPremiumEntitlement`.
+
+## 10.3 — get_institutions: returns connected institutions
+Call `get_institutions()`.
+**Expected:** JSON with institution/credential data. May have `credentials` key with a list.
+
+## 10.4 — get_cashflow_summary: no dates
+Call `get_cashflow_summary()`.
+**Expected:** JSON with cashflow summary data.
+
+## 10.5 — get_cashflow_summary: with dates
+Call `get_cashflow_summary(start_date="2025-01-01", end_date="2025-01-31")`.
+**Expected:** JSON with cashflow summary for the specified period.
+
+## 10.6 — get_cashflow_summary: only start_date -> error
+Call `get_cashflow_summary(start_date="2025-01-01")`.
+**Expected:** JSON with `error` key about requiring both dates.
+
+## 10.7 — get_recurring_transactions: no dates
+Call `get_recurring_transactions()`.
+**Expected:** JSON with recurring transaction data.
+
+## 10.8 — get_recurring_transactions: with dates
+Call `get_recurring_transactions(start_date="2025-01-01", end_date="2025-12-31")`.
+**Expected:** JSON with recurring transaction data for the period.
+
+## 10.9 — get_recurring_transactions: only end_date -> error
+Call `get_recurring_transactions(end_date="2025-12-31")`.
+**Expected:** JSON with `error` key.
+
+## 10.10 — set_budget_amount: with category_id
+Pick a `category_id` from the categories discovered in Phase 8 (or use `{valid_category_id}`).
+Call `set_budget_amount(amount=500.0, category_id={valid_category_id})`.
+**Expected:** Success response.
+
+## 10.11 — set_budget_amount: both IDs -> error
+Call `set_budget_amount(amount=100.0, category_id="cat-1", category_group_id="grp-1")`.
+**Expected:** JSON with `error` key about providing exactly one.
+
+## 10.12 — set_budget_amount: neither ID -> error
+Call `set_budget_amount(amount=100.0)`.
+**Expected:** JSON with `error` key about providing exactly one.

--- a/.claude/skills/test-monarch-mcp/references/transaction-details-and-splits.md
+++ b/.claude/skills/test-monarch-mcp/references/transaction-details-and-splits.md
@@ -1,0 +1,37 @@
+# Phase 9 — Transaction Details & Splits (8 tests)
+
+## 9.1 — get_transaction_details: happy path
+Call `get_transaction_details(transaction_id={test_transaction_id})`.
+**Expected:** JSON with detailed transaction info including `id`, `date`, `amount`, `merchant`, `category`.
+
+## 9.2 — get_transaction_details: redirect_posted=False
+Call `get_transaction_details(transaction_id={test_transaction_id}, redirect_posted=False)`.
+**Expected:** Success. Returns transaction details.
+
+## 9.3 — get_transaction_details: invalid ID
+Call `get_transaction_details(transaction_id="invalid-txn-id")`.
+**Expected:** Error response.
+
+## 9.4 — get_transaction_splits: no splits
+Call `get_transaction_splits(transaction_id={test_transaction_id})`.
+**Expected:** JSON response. The `splitTransactions` list is likely empty for the test transaction.
+
+## 9.5 — get_transaction_splits: invalid ID
+Call `get_transaction_splits(transaction_id="invalid-txn-id")`.
+**Expected:** Error response.
+
+## 9.6 — update_transaction_splits: create splits on test transaction
+First, create a temporary transaction for split testing:
+Call `create_transaction(account_id={checking_account_id}, amount=-100.0, merchant_name="MCP-Test-Split-Merchant", category_id={valid_category_id}, date="2025-01-15")`.
+Record the ID in `created_resources.transactions`.
+
+Then call `update_transaction_splits(transaction_id={new_txn_id}, split_data=[{"merchantName": "Part A", "amount": -60.0, "categoryId": "{valid_category_id}"}, {"merchantName": "Part B", "amount": -40.0, "categoryId": "{valid_category_id}"}])`.
+**Expected:** Success.
+
+## 9.7 — get_transaction_splits: verify splits exist
+Call `get_transaction_splits(transaction_id={new_txn_id from 9.6})`.
+**Expected:** Response contains 2 split transactions.
+
+## 9.8 — update_transaction_splits: remove all splits
+Call `update_transaction_splits(transaction_id={new_txn_id from 9.6}, split_data=[])`.
+**Expected:** Success. Splits are removed.

--- a/README.md
+++ b/README.md
@@ -78,17 +78,38 @@ Once authenticated, use these tools directly in Claude Desktop:
 ### 📊 Account Management
 - **Get Accounts**: View all linked financial accounts with balances and institution info
 - **Get Account Holdings**: See securities and investments in investment accounts
+- **Create Manual Account**: Add manual accounts (property, crypto, etc.)
+- **Update Account**: Modify account settings (name, balance, net worth inclusion, visibility)
+- **Delete Account**: Remove an account permanently
 - **Refresh Accounts**: Request real-time data updates from financial institutions
+- **Get Institutions**: View connected financial institutions and their sync status
+- **Account History & Snapshots**: Historical balance data, daily balances, and net worth snapshots
 
 ### 💰 Transaction Access
-- **Get Transactions**: Fetch transaction data with filtering by date, account, and pagination
-- **Create Transaction**: Add new transactions to accounts
+- **Get Transactions**: Fetch with advanced filtering — search, categories, tags, date ranges, account, boolean flags (has notes, is recurring, is split, etc.)
+- **Get Transaction Details**: Full detail for a single transaction including attachments and splits
+- **Create Transaction**: Add new transactions with optional balance update
 - **Update Transaction**: Modify existing transactions (amount, description, category, date)
-- **Tag Management**: Create, view, and apply tags to organize and categorize transactions
+- **Transaction Splits**: View and manage split transactions
+- **Tag Management**: Create, view, delete, and apply tags to organize transactions
 
 ### 📈 Financial Analysis
 - **Get Budgets**: Access budget information including spent amounts and remaining balances
-- **Get Cashflow**: Analyze financial cashflow over specified date ranges with income/expense breakdowns
+- **Set Budget Amount**: Set or update budget amounts for categories or category groups
+- **Get Cashflow**: Analyze financial cashflow with income/expense breakdowns
+- **Get Cashflow Summary**: Quick summary of income, expenses, savings, and savings rate
+- **Get Transactions Summary**: Aggregate stats (count, sum, avg, max, income, expenses)
+- **Get Recurring Transactions**: View subscriptions and recurring bills
+- **Get Credit History**: Credit score history and trends
+
+### 🏷️ Category Management
+- **Get Categories**: View all transaction categories and their groups
+- **Create Category**: Add new categories with optional rollover settings
+- **Delete Category**: Remove a transaction category
+
+### 📋 Account Info
+- **Get Subscription Details**: Check Monarch Money subscription status
+- **Get Account Type Options**: View available account types for manual account creation
 
 ### 🔐 Secure Authentication
 - **Auto Browser Login**: A login page opens in your browser automatically when needed
@@ -99,21 +120,53 @@ Once authenticated, use these tools directly in Claude Desktop:
 
 ## 🛠️ Available Tools
 
-| Tool | Description | Parameters |
-|------|-------------|------------|
+| Tool | Description | Key Parameters |
+|------|-------------|----------------|
+| **Auth** | | |
 | `setup_authentication` | Get setup instructions | None |
 | `check_auth_status` | Check authentication status | None |
+| `debug_session_loading` | Debug keyring issues | None |
+| **Accounts** | | |
 | `get_accounts` | Get all financial accounts | None |
-| `get_transactions` | Get transactions with filtering | `limit`, `offset`, `start_date`, `end_date`, `account_id` |
-| `get_budgets` | Get budget information | None |
-| `get_cashflow` | Get cashflow analysis | `start_date`, `end_date` |
 | `get_account_holdings` | Get investment holdings | `account_id` |
-| `create_transaction` | Create new transaction | `account_id`, `amount`, `description`, `date`, `category_id`, `merchant_name` |
-| `update_transaction` | Update existing transaction | `transaction_id`, `amount`, `description`, `category_id`, `date` |
+| `create_manual_account` | Create manual account | `account_name`, `account_type`, `account_sub_type`, `is_in_net_worth` |
+| `update_account` | Update account settings | `account_id`, `account_name`, `account_balance`, `include_in_net_worth`, ... |
+| `delete_account` | Delete an account | `account_id` |
 | `refresh_accounts` | Request account data refresh | None |
-| `get_transaction_tags` | Get all transaction tags | None |
-| `create_transaction_tag` | Create new transaction tag | `name`, `color` |
+| `get_institutions` | Get connected institutions | None |
+| `get_account_type_options` | Get valid account types | None |
+| `get_account_history` | Get historical balance data | `account_id` |
+| `get_recent_account_balances` | Get daily balances | `start_date` |
+| `get_account_snapshots_by_type` | Net worth by account type | `start_date`, `timeframe` |
+| `get_aggregate_snapshots` | Daily aggregate net value | `start_date`, `end_date`, `account_type` |
+| **Transactions** | | |
+| `get_transactions` | Get transactions with filtering | `limit`, `offset`, `start_date`, `end_date`, `account_id`, `search`, `category_ids`, `tag_ids`, `is_recurring`, ... |
+| `get_transaction_details` | Get full transaction detail | `transaction_id`, `redirect_posted` |
+| `get_transactions_summary` | Aggregate transaction stats | None |
+| `create_transaction` | Create new transaction | `account_id`, `amount`, `merchant_name`, `category_id`, `date`, `notes`, `update_balance` |
+| `update_transaction` | Update existing transaction | `transaction_id`, `amount`, `merchant_name`, `category_id`, `date`, `notes`, ... |
+| `delete_transaction` | Delete a transaction | `transaction_id` |
+| `get_transaction_splits` | Get split information | `transaction_id` |
+| `update_transaction_splits` | Create/modify/delete splits | `transaction_id`, `split_data` |
+| `get_recurring_transactions` | Get recurring transactions | `start_date`, `end_date` |
+| **Tags** | | |
+| `get_transaction_tags` | Get all tags | None |
+| `create_transaction_tag` | Create new tag | `name`, `color` |
+| `delete_transaction_tag` | Delete a tag | `tag_id` |
 | `set_transaction_tags` | Set tags on a transaction | `transaction_id`, `tag_ids` |
+| **Categories** | | |
+| `get_transaction_categories` | Get all categories | None |
+| `get_transaction_category_groups` | Get category groups | None |
+| `create_transaction_category` | Create a category | `group_id`, `name`, `icon`, `rollover_enabled` |
+| `delete_transaction_category` | Delete a category | `category_id` |
+| **Budgets & Cashflow** | | |
+| `get_budgets` | Get budget information | `start_date`, `end_date`, `use_v2_goals` |
+| `set_budget_amount` | Set budget for category | `amount`, `category_id` or `category_group_id`, `timeframe`, `apply_to_future` |
+| `get_cashflow` | Get cashflow analysis | `start_date`, `end_date` |
+| `get_cashflow_summary` | Get cashflow summary | `limit`, `start_date`, `end_date` |
+| **Other** | | |
+| `get_subscription_details` | Get subscription status | None |
+| `get_credit_history` | Get credit score history | None |
 
 ## 📝 Usage Examples
 

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -1013,9 +1013,13 @@ def delete_transaction_category(category_id: str) -> str:
         client = await get_monarch_client()
         return await client.delete_transaction_category(category_id)
 
-    run_async(_delete_transaction_category())
+    result = run_async(_delete_transaction_category())
 
-    return json.dumps({"deleted": True, "category_id": category_id}, indent=2)
+    return json.dumps(
+        {"deleted": True, "category_id": category_id, "result": result},
+        indent=2,
+        default=str,
+    )
 
 
 @mcp.tool()
@@ -1191,6 +1195,7 @@ def get_aggregate_snapshots(
     async def _get_aggregate_snapshots():
         client = await get_monarch_client()
         kwargs = {}
+        # monarchmoney library requires date objects (not strings) for this method
         if start_date is not None:
             kwargs["start_date"] = datetime.strptime(start_date, "%Y-%m-%d").date()
         if end_date is not None:
@@ -1246,9 +1251,13 @@ def delete_account(account_id: str) -> str:
         client = await get_monarch_client()
         return await client.delete_account(account_id)
 
-    run_async(_delete_account())
+    result = run_async(_delete_account())
 
-    return json.dumps({"deleted": True, "account_id": account_id}, indent=2)
+    return json.dumps(
+        {"deleted": True, "account_id": account_id, "result": result},
+        indent=2,
+        default=str,
+    )
 
 
 def main():

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -1,4 +1,5 @@
 """Monarch Money MCP Server - Main server implementation."""
+# pylint: disable=too-many-lines
 
 import functools
 import json
@@ -6,7 +7,8 @@ import logging
 import os
 import re
 import traceback
-from typing import List, Optional
+from datetime import datetime
+from typing import Any, Dict, List, Optional
 from concurrent.futures import ThreadPoolExecutor
 
 from dotenv import load_dotenv
@@ -239,12 +241,22 @@ def get_accounts() -> str:
 
 @mcp.tool()
 @_handle_mcp_errors("getting transactions")
-def get_transactions(
+def get_transactions(  # pylint: disable=too-many-arguments,too-many-positional-arguments,too-many-locals,too-many-branches
     limit: int = 100,
     offset: int = 0,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
     account_id: Optional[str] = None,
+    search: Optional[str] = None,
+    category_ids: Optional[List[str]] = None,
+    account_ids: Optional[List[str]] = None,
+    tag_ids: Optional[List[str]] = None,
+    has_attachments: Optional[bool] = None,
+    has_notes: Optional[bool] = None,
+    hidden_from_reports: Optional[bool] = None,
+    is_split: Optional[bool] = None,
+    is_recurring: Optional[bool] = None,
+    synced_from_institution: Optional[bool] = None,
 ) -> str:
     """
     Get transactions from Monarch Money.
@@ -254,11 +266,27 @@ def get_transactions(
         offset: Number of transactions to skip (default: 0)
         start_date: Start date in YYYY-MM-DD format (requires end_date)
         end_date: End date in YYYY-MM-DD format (requires start_date)
-        account_id: Specific account ID to filter by
+        account_id: Specific account ID to filter by (shorthand for account_ids with one ID)
+        search: Free text search query
+        category_ids: List of category IDs to filter by
+        account_ids: List of account IDs to filter by (cannot use with account_id)
+        tag_ids: List of tag IDs to filter by
+        has_attachments: Filter transactions with/without attachments
+        has_notes: Filter transactions with/without notes
+        hidden_from_reports: Filter transactions hidden/visible in reports
+        is_split: Filter split/unsplit transactions
+        is_recurring: Filter recurring/non-recurring transactions
+        synced_from_institution: Filter synced/manual transactions
     """
     if bool(start_date) != bool(end_date):
         return json.dumps(
             {"error": "Both start_date and end_date are required when filtering by date."},
+            indent=2,
+        )
+
+    if account_id and account_ids:
+        return json.dumps(
+            {"error": "Cannot use both account_id and account_ids. Use one or the other."},
             indent=2,
         )
 
@@ -272,6 +300,26 @@ def get_transactions(
             filters["end_date"] = end_date
         if account_id:
             filters["account_ids"] = [account_id]
+        if account_ids:
+            filters["account_ids"] = account_ids
+        if search:
+            filters["search"] = search
+        if category_ids:
+            filters["category_ids"] = category_ids
+        if tag_ids:
+            filters["tag_ids"] = tag_ids
+        if has_attachments is not None:
+            filters["has_attachments"] = has_attachments
+        if has_notes is not None:
+            filters["has_notes"] = has_notes
+        if hidden_from_reports is not None:
+            filters["hidden_from_reports"] = hidden_from_reports
+        if is_split is not None:
+            filters["is_split"] = is_split
+        if is_recurring is not None:
+            filters["is_recurring"] = is_recurring
+        if synced_from_institution is not None:
+            filters["synced_from_institution"] = synced_from_institution
 
         return await client.get_transactions(limit=limit, offset=offset, **filters)
 
@@ -312,7 +360,9 @@ def get_transactions(
 @mcp.tool()
 @_handle_mcp_errors("getting budgets")
 def get_budgets(
-    start_date: Optional[str] = None, end_date: Optional[str] = None
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    use_v2_goals: bool = True,
 ) -> str:
     """
     Get budget information from Monarch Money.
@@ -320,6 +370,7 @@ def get_budgets(
     Args:
         start_date: Start date in YYYY-MM-DD format (default: last month)
         end_date: End date in YYYY-MM-DD format (default: next month)
+        use_v2_goals: Whether to use v2 goals format (default: True)
     """
     if bool(start_date) != bool(end_date):
         return json.dumps(
@@ -334,7 +385,7 @@ def get_budgets(
             filters["start_date"] = start_date
         if end_date is not None:
             filters["end_date"] = end_date
-        return await client.get_budgets(**filters)
+        return await client.get_budgets(use_v2_goals=use_v2_goals, **filters)
 
     budgets = run_async(_get_budgets())
 
@@ -403,6 +454,7 @@ def create_transaction(  # pylint: disable=too-many-arguments,too-many-positiona
     category_id: str,
     date: str,
     notes: Optional[str] = None,
+    update_balance: bool = False,
 ) -> str:
     """
     Create a new transaction in Monarch Money.
@@ -414,6 +466,7 @@ def create_transaction(  # pylint: disable=too-many-arguments,too-many-positiona
         category_id: Category ID for the transaction
         date: Transaction date in YYYY-MM-DD format
         notes: Optional transaction notes
+        update_balance: Whether to update the account balance (default: False)
     """
 
     async def _create_transaction():
@@ -425,6 +478,7 @@ def create_transaction(  # pylint: disable=too-many-arguments,too-many-positiona
             merchant_name=merchant_name,
             category_id=category_id,
             notes=notes or "",
+            update_balance=update_balance,
         )
 
     result = run_async(_create_transaction())
@@ -641,6 +695,560 @@ def set_transaction_tags(transaction_id: str, tag_ids: List[str]) -> str:
     result = run_async(_set_transaction_tags())
 
     return json.dumps(result, indent=2, default=str)
+
+
+# ── Phase 2: Read-only tools ──────────────────────────────────────────
+
+
+@mcp.tool()
+@_handle_mcp_errors("getting transaction categories")
+def get_transaction_categories() -> str:
+    """Get all transaction categories from Monarch Money."""
+
+    async def _get_transaction_categories():
+        client = await get_monarch_client()
+        return await client.get_transaction_categories()
+
+    categories = run_async(_get_transaction_categories())
+
+    return json.dumps(categories, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_mcp_errors("getting transaction category groups")
+def get_transaction_category_groups() -> str:
+    """Get all transaction category groups from Monarch Money."""
+
+    async def _get_transaction_category_groups():
+        client = await get_monarch_client()
+        return await client.get_transaction_category_groups()
+
+    groups = run_async(_get_transaction_category_groups())
+
+    return json.dumps(groups, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_mcp_errors("getting transaction details")
+def get_transaction_details(
+    transaction_id: str,
+    redirect_posted: bool = True,
+) -> str:
+    """
+    Get detailed information about a specific transaction.
+
+    Args:
+        transaction_id: The ID of the transaction
+        redirect_posted: Whether to redirect to posted transaction (default: True)
+    """
+
+    async def _get_transaction_details():
+        client = await get_monarch_client()
+        return await client.get_transaction_details(
+            transaction_id, redirect_posted=redirect_posted,
+        )
+
+    details = run_async(_get_transaction_details())
+
+    return json.dumps(details, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_mcp_errors("getting recurring transactions")
+def get_recurring_transactions(
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> str:
+    """
+    Get recurring transactions from Monarch Money.
+
+    Args:
+        start_date: Start date in YYYY-MM-DD format (requires end_date)
+        end_date: End date in YYYY-MM-DD format (requires start_date)
+    """
+    if bool(start_date) != bool(end_date):
+        return json.dumps(
+            {"error": "Both start_date and end_date are required when filtering by date."},
+            indent=2,
+        )
+
+    async def _get_recurring_transactions():
+        client = await get_monarch_client()
+        filters = {}
+        if start_date:
+            filters["start_date"] = start_date
+        if end_date:
+            filters["end_date"] = end_date
+        return await client.get_recurring_transactions(**filters)
+
+    result = run_async(_get_recurring_transactions())
+
+    return json.dumps(result, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_mcp_errors("getting transactions summary")
+def get_transactions_summary() -> str:
+    """Get aggregate transaction summary (count, sum, avg, max, income, expenses)."""
+
+    async def _get_transactions_summary():
+        client = await get_monarch_client()
+        return await client.get_transactions_summary()
+
+    summary = run_async(_get_transactions_summary())
+
+    return json.dumps(summary, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_mcp_errors("getting subscription details")
+def get_subscription_details() -> str:
+    """Get Monarch Money subscription status and details."""
+
+    async def _get_subscription_details():
+        client = await get_monarch_client()
+        return await client.get_subscription_details()
+
+    details = run_async(_get_subscription_details())
+
+    return json.dumps(details, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_mcp_errors("getting institutions")
+def get_institutions() -> str:
+    """Get all connected financial institutions and their connection status."""
+
+    async def _get_institutions():
+        client = await get_monarch_client()
+        return await client.get_institutions()
+
+    institutions = run_async(_get_institutions())
+
+    return json.dumps(institutions, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_mcp_errors("getting cashflow summary")
+def get_cashflow_summary(
+    limit: int = 100,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+) -> str:
+    """
+    Get cashflow summary (income, expenses, savings, savings rate).
+
+    Args:
+        limit: Number of records to retrieve (default: 100)
+        start_date: Start date in YYYY-MM-DD format (requires end_date)
+        end_date: End date in YYYY-MM-DD format (requires start_date)
+    """
+    if bool(start_date) != bool(end_date):
+        return json.dumps(
+            {"error": "Both start_date and end_date are required when filtering by date."},
+            indent=2,
+        )
+
+    async def _get_cashflow_summary():
+        client = await get_monarch_client()
+        filters = {}
+        if start_date:
+            filters["start_date"] = start_date
+        if end_date:
+            filters["end_date"] = end_date
+        return await client.get_cashflow_summary(limit=limit, **filters)
+
+    summary = run_async(_get_cashflow_summary())
+
+    return json.dumps(summary, indent=2, default=str)
+
+
+# ── Phase 3: Mutation tools ──────────────────────────────────────────
+
+
+@mcp.tool()
+@_handle_mcp_errors("setting budget amount")
+def set_budget_amount(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    amount: float,
+    category_id: Optional[str] = None,
+    category_group_id: Optional[str] = None,
+    timeframe: str = "month",
+    start_date: Optional[str] = None,
+    apply_to_future: bool = False,
+) -> str:
+    """
+    Set or update a budget amount for a category or category group.
+
+    Args:
+        amount: The budget amount to set
+        category_id: Category ID (mutually exclusive with category_group_id)
+        category_group_id: Category group ID (mutually exclusive with category_id)
+        timeframe: Budget timeframe - "month" or "week" (default: "month")
+        start_date: Budget start date in YYYY-MM-DD format
+        apply_to_future: Whether to apply this amount to future periods (default: False)
+    """
+    if (category_id is None) == (category_group_id is None):
+        return json.dumps(
+            {"error": "Provide exactly one of category_id or category_group_id."},
+            indent=2,
+        )
+
+    async def _set_budget_amount():
+        client = await get_monarch_client()
+        kwargs = {
+            "amount": amount,
+            "timeframe": timeframe,
+            "apply_to_future": apply_to_future,
+        }
+        if category_id is not None:
+            kwargs["category_id"] = category_id
+        if category_group_id is not None:
+            kwargs["category_group_id"] = category_group_id
+        if start_date is not None:
+            kwargs["start_date"] = start_date
+        return await client.set_budget_amount(**kwargs)
+
+    result = run_async(_set_budget_amount())
+
+    return json.dumps(result, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_mcp_errors("getting transaction splits")
+def get_transaction_splits(transaction_id: str) -> str:
+    """
+    Get split information for a transaction.
+
+    Args:
+        transaction_id: The ID of the transaction
+    """
+
+    async def _get_transaction_splits():
+        client = await get_monarch_client()
+        return await client.get_transaction_splits(transaction_id)
+
+    splits = run_async(_get_transaction_splits())
+
+    return json.dumps(splits, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_mcp_errors("updating transaction splits")
+def update_transaction_splits(
+    transaction_id: str,
+    split_data: List[Dict[str, Any]],
+) -> str:
+    """
+    Create, modify, or delete splits for a transaction.
+
+    Args:
+        transaction_id: The ID of the transaction to split
+        split_data: List of split objects, each with keys: merchantName, amount, categoryId.
+            Sum of split amounts must equal the original transaction amount.
+            Pass an empty list to remove all splits.
+    """
+
+    async def _update_transaction_splits():
+        client = await get_monarch_client()
+        return await client.update_transaction_splits(transaction_id, split_data)
+
+    result = run_async(_update_transaction_splits())
+
+    return json.dumps(result, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_mcp_errors("creating transaction category")
+def create_transaction_category(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    group_id: str,
+    name: str,
+    icon: str = "\u2753",
+    rollover_enabled: bool = False,
+    rollover_type: str = "monthly",
+    rollover_start_month: Optional[str] = None,
+) -> str:
+    """
+    Create a new transaction category in Monarch Money.
+
+    Args:
+        group_id: The category group ID this category belongs to
+        name: The category name
+        icon: Category icon (default: question mark emoji)
+        rollover_enabled: Whether budget rollover is enabled (default: False)
+        rollover_type: Rollover type - "monthly" (default: "monthly")
+        rollover_start_month: Rollover start in YYYY-MM-DD (default: 1st of month)
+    """
+
+    async def _create_transaction_category():
+        client = await get_monarch_client()
+        kwargs = {
+            "group_id": group_id,
+            "transaction_category_name": name,
+            "icon": icon,
+            "rollover_enabled": rollover_enabled,
+            "rollover_type": rollover_type,
+        }
+        if rollover_start_month is not None:
+            kwargs["rollover_start_month"] = datetime.strptime(
+                rollover_start_month, "%Y-%m-%d",
+            )
+        return await client.create_transaction_category(**kwargs)
+
+    result = run_async(_create_transaction_category())
+
+    return json.dumps(result, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_mcp_errors("deleting transaction category")
+def delete_transaction_category(category_id: str) -> str:
+    """
+    Delete a transaction category from Monarch Money.
+
+    Args:
+        category_id: The ID of the category to delete
+    """
+
+    async def _delete_transaction_category():
+        client = await get_monarch_client()
+        return await client.delete_transaction_category(category_id)
+
+    run_async(_delete_transaction_category())
+
+    return json.dumps({"deleted": True, "category_id": category_id}, indent=2)
+
+
+@mcp.tool()
+@_handle_mcp_errors("creating manual account")
+def create_manual_account(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    account_name: str,
+    account_type: str,
+    account_sub_type: str,
+    is_in_net_worth: bool,
+    account_balance: float = 0,
+) -> str:
+    """
+    Create a new manual account in Monarch Money.
+
+    Args:
+        account_name: Name for the account
+        account_type: Account type (use get_account_type_options to see valid types)
+        account_sub_type: Account sub-type
+        is_in_net_worth: Whether to include in net worth calculation
+        account_balance: Starting balance (default: 0)
+    """
+
+    async def _create_manual_account():
+        client = await get_monarch_client()
+        return await client.create_manual_account(
+            account_type=account_type,
+            account_sub_type=account_sub_type,
+            is_in_net_worth=is_in_net_worth,
+            account_name=account_name,
+            account_balance=account_balance,
+        )
+
+    result = run_async(_create_manual_account())
+
+    return json.dumps(result, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_mcp_errors("updating account")
+def update_account(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    account_id: str,
+    account_name: Optional[str] = None,
+    account_balance: Optional[float] = None,
+    account_type: Optional[str] = None,
+    account_sub_type: Optional[str] = None,
+    include_in_net_worth: Optional[bool] = None,
+    hide_from_summary_list: Optional[bool] = None,
+    hide_transactions_from_reports: Optional[bool] = None,
+) -> str:
+    """
+    Update an existing account in Monarch Money.
+
+    Args:
+        account_id: The ID of the account to update
+        account_name: New account name
+        account_balance: New account balance
+        account_type: New account type
+        account_sub_type: New account sub-type
+        include_in_net_worth: Whether to include in net worth
+        hide_from_summary_list: Whether to hide from summary list
+        hide_transactions_from_reports: Whether to hide transactions from reports
+    """
+
+    async def _update_account():
+        client = await get_monarch_client()
+        update_data = {"account_id": account_id}
+        if account_name is not None:
+            update_data["account_name"] = account_name
+        if account_balance is not None:
+            update_data["account_balance"] = account_balance
+        if account_type is not None:
+            update_data["account_type"] = account_type
+        if account_sub_type is not None:
+            update_data["account_sub_type"] = account_sub_type
+        if include_in_net_worth is not None:
+            update_data["include_in_net_worth"] = include_in_net_worth
+        if hide_from_summary_list is not None:
+            update_data["hide_from_summary_list"] = hide_from_summary_list
+        if hide_transactions_from_reports is not None:
+            update_data["hide_transactions_from_reports"] = hide_transactions_from_reports
+        return await client.update_account(**update_data)
+
+    result = run_async(_update_account())
+
+    return json.dumps(result, indent=2, default=str)
+
+
+# ── Phase 4: Analytics & history tools ────────────────────────────────
+
+
+@mcp.tool()
+@_handle_mcp_errors("getting account history")
+def get_account_history(account_id: str) -> str:
+    """
+    Get historical balance snapshots for an account.
+
+    Args:
+        account_id: The ID of the account
+    """
+
+    async def _get_account_history():
+        client = await get_monarch_client()
+        return await client.get_account_history(account_id)
+
+    history = run_async(_get_account_history())
+
+    return json.dumps(history, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_mcp_errors("getting recent account balances")
+def get_recent_account_balances(start_date: Optional[str] = None) -> str:
+    """
+    Get daily balance for all accounts from a start date.
+
+    Args:
+        start_date: Start date in YYYY-MM-DD format (optional)
+    """
+
+    async def _get_recent_account_balances():
+        client = await get_monarch_client()
+        kwargs = {}
+        if start_date is not None:
+            kwargs["start_date"] = start_date
+        return await client.get_recent_account_balances(**kwargs)
+
+    balances = run_async(_get_recent_account_balances())
+
+    return json.dumps(balances, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_mcp_errors("getting account snapshots by type")
+def get_account_snapshots_by_type(start_date: str, timeframe: str) -> str:
+    """
+    Get net value snapshots grouped by account type.
+
+    Args:
+        start_date: Start date in YYYY-MM-DD format
+        timeframe: Aggregation period - "month" or "year"
+    """
+    if timeframe not in ("month", "year"):
+        return json.dumps(
+            {"error": "timeframe must be 'month' or 'year'."},
+            indent=2,
+        )
+
+    async def _get_account_snapshots_by_type():
+        client = await get_monarch_client()
+        return await client.get_account_snapshots_by_type(start_date, timeframe)
+
+    snapshots = run_async(_get_account_snapshots_by_type())
+
+    return json.dumps(snapshots, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_mcp_errors("getting aggregate snapshots")
+def get_aggregate_snapshots(
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    account_type: Optional[str] = None,
+) -> str:
+    """
+    Get daily aggregate net value of all accounts.
+
+    Args:
+        start_date: Start date in YYYY-MM-DD format
+        end_date: End date in YYYY-MM-DD format
+        account_type: Filter by account type (optional)
+    """
+
+    async def _get_aggregate_snapshots():
+        client = await get_monarch_client()
+        kwargs = {}
+        if start_date is not None:
+            kwargs["start_date"] = datetime.strptime(start_date, "%Y-%m-%d").date()
+        if end_date is not None:
+            kwargs["end_date"] = datetime.strptime(end_date, "%Y-%m-%d").date()
+        if account_type is not None:
+            kwargs["account_type"] = account_type
+        return await client.get_aggregate_snapshots(**kwargs)
+
+    snapshots = run_async(_get_aggregate_snapshots())
+
+    return json.dumps(snapshots, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_mcp_errors("getting account type options")
+def get_account_type_options() -> str:
+    """Get available account types and sub-types for creating manual accounts."""
+
+    async def _get_account_type_options():
+        client = await get_monarch_client()
+        return await client.get_account_type_options()
+
+    options = run_async(_get_account_type_options())
+
+    return json.dumps(options, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_mcp_errors("getting credit history")
+def get_credit_history() -> str:
+    """Get credit score history and related details."""
+
+    async def _get_credit_history():
+        client = await get_monarch_client()
+        return await client.get_credit_history()
+
+    history = run_async(_get_credit_history())
+
+    return json.dumps(history, indent=2, default=str)
+
+
+@mcp.tool()
+@_handle_mcp_errors("deleting account")
+def delete_account(account_id: str) -> str:
+    """
+    Delete an account from Monarch Money. This action is irreversible.
+
+    Args:
+        account_id: The ID of the account to delete
+    """
+
+    async def _delete_account():
+        client = await get_monarch_client()
+        return await client.delete_account(account_id)
+
+    run_async(_delete_account())
+
+    return json.dumps({"deleted": True, "account_id": account_id}, indent=2)
 
 
 def main():

--- a/tests/test_account_management.py
+++ b/tests/test_account_management.py
@@ -1,0 +1,336 @@
+"""Tests for account management tools: create, update, delete, history, snapshots."""
+# pylint: disable=missing-function-docstring
+
+import json
+
+from monarch_mcp_server.server import (
+    create_manual_account,
+    update_account,
+    delete_account,
+    get_account_history,
+    get_recent_account_balances,
+    get_account_snapshots_by_type,
+    get_aggregate_snapshots,
+    get_account_type_options,
+    get_credit_history,
+)
+
+
+# ===================================================================
+# create_manual_account
+# ===================================================================
+
+
+def test_create_account_happy(mock_monarch_client):
+    mock_monarch_client.create_manual_account.return_value = {
+        "createManualAccount": {"id": "acc-new", "displayName": "Savings"}
+    }
+
+    result = json.loads(
+        create_manual_account(
+            account_name="Savings",
+            account_type="depository",
+            account_sub_type="savings",
+            is_in_net_worth=True,
+            account_balance=1000.0,
+        )
+    )
+
+    assert result["createManualAccount"]["id"] == "acc-new"
+    mock_monarch_client.create_manual_account.assert_called_once_with(
+        account_type="depository",
+        account_sub_type="savings",
+        is_in_net_worth=True,
+        account_name="Savings",
+        account_balance=1000.0,
+    )
+
+
+def test_create_account_default_balance(mock_monarch_client):
+    mock_monarch_client.create_manual_account.return_value = {
+        "createManualAccount": {"id": "acc-new"}
+    }
+
+    create_manual_account(
+        account_name="Test",
+        account_type="loan",
+        account_sub_type="personal",
+        is_in_net_worth=False,
+    )
+
+    call_kwargs = mock_monarch_client.create_manual_account.call_args[1]
+    assert call_kwargs["account_balance"] == 0
+
+
+def test_create_account_error(mock_monarch_client):
+    mock_monarch_client.create_manual_account.side_effect = Exception(
+        "Invalid type"
+    )
+
+    result = create_manual_account(
+        account_name="Bad",
+        account_type="invalid",
+        account_sub_type="bad",
+        is_in_net_worth=True,
+    )
+
+    assert "Error" in result
+
+
+# ===================================================================
+# update_account
+# ===================================================================
+
+
+def test_update_account_name(mock_monarch_client):
+    mock_monarch_client.update_account.return_value = {
+        "id": "acc-1",
+        "displayName": "New Name",
+    }
+
+    result = json.loads(
+        update_account(account_id="acc-1", account_name="New Name")
+    )
+
+    assert result["displayName"] == "New Name"
+    call_kwargs = mock_monarch_client.update_account.call_args[1]
+    assert call_kwargs["account_id"] == "acc-1"
+    assert call_kwargs["account_name"] == "New Name"
+
+
+def test_update_account_balance(mock_monarch_client):
+    mock_monarch_client.update_account.return_value = {
+        "id": "acc-1",
+        "currentBalance": 5000.0,
+    }
+
+    result = json.loads(
+        update_account(account_id="acc-1", account_balance=5000.0)
+    )
+
+    assert result["currentBalance"] == 5000.0
+
+
+def test_update_account_noop(mock_monarch_client):
+    mock_monarch_client.update_account.return_value = {"id": "acc-1"}
+
+    result = json.loads(update_account(account_id="acc-1"))
+
+    assert result["id"] == "acc-1"
+    call_kwargs = mock_monarch_client.update_account.call_args[1]
+    assert call_kwargs == {"account_id": "acc-1"}
+
+
+def test_update_account_multi_field(mock_monarch_client):
+    mock_monarch_client.update_account.return_value = {"id": "acc-1"}
+
+    update_account(
+        account_id="acc-1",
+        account_name="Updated",
+        include_in_net_worth=False,
+        hide_from_summary_list=True,
+    )
+
+    call_kwargs = mock_monarch_client.update_account.call_args[1]
+    assert call_kwargs["account_name"] == "Updated"
+    assert call_kwargs["include_in_net_worth"] is False
+    assert call_kwargs["hide_from_summary_list"] is True
+
+
+def test_update_account_error(mock_monarch_client):
+    mock_monarch_client.update_account.side_effect = Exception("Not found")
+
+    result = update_account(account_id="bad-id", account_name="X")
+
+    assert "Error" in result
+
+
+# ===================================================================
+# delete_account
+# ===================================================================
+
+
+def test_delete_account_happy(mock_monarch_client):
+    mock_monarch_client.delete_account.return_value = None
+
+    result = json.loads(delete_account(account_id="acc-1"))
+
+    assert result["deleted"] is True
+    assert result["account_id"] == "acc-1"
+    mock_monarch_client.delete_account.assert_called_once_with("acc-1")
+
+
+def test_delete_account_error(mock_monarch_client):
+    mock_monarch_client.delete_account.side_effect = Exception("Account not found")
+
+    result = delete_account(account_id="bad-id")
+
+    assert "Error" in result
+
+
+# ===================================================================
+# get_account_history
+# ===================================================================
+
+
+def test_account_history_happy(mock_monarch_client):
+    mock_monarch_client.get_account_history.return_value = {
+        "accountHistory": [
+            {"date": "2025-01-01", "balance": 1000},
+            {"date": "2025-01-02", "balance": 1050},
+        ]
+    }
+
+    result = json.loads(get_account_history(account_id="acc-1"))
+
+    assert len(result["accountHistory"]) == 2
+    mock_monarch_client.get_account_history.assert_called_once_with("acc-1")
+
+
+def test_account_history_error(mock_monarch_client):
+    mock_monarch_client.get_account_history.side_effect = Exception("Not found")
+
+    result = get_account_history(account_id="bad-id")
+
+    assert "Error" in result
+
+
+# ===================================================================
+# get_recent_account_balances
+# ===================================================================
+
+
+def test_recent_balances_no_date(mock_monarch_client):
+    mock_monarch_client.get_recent_account_balances.return_value = {
+        "recentAccountBalances": []
+    }
+
+    result = json.loads(get_recent_account_balances())
+
+    mock_monarch_client.get_recent_account_balances.assert_called_once_with()
+
+
+def test_recent_balances_with_date(mock_monarch_client):
+    mock_monarch_client.get_recent_account_balances.return_value = {
+        "recentAccountBalances": [{"date": "2025-01-01", "balance": 1000}]
+    }
+
+    get_recent_account_balances(start_date="2025-01-01")
+
+    mock_monarch_client.get_recent_account_balances.assert_called_once_with(
+        start_date="2025-01-01"
+    )
+
+
+# ===================================================================
+# get_account_snapshots_by_type
+# ===================================================================
+
+
+def test_snapshots_by_type_month(mock_monarch_client):
+    mock_monarch_client.get_account_snapshots_by_type.return_value = {
+        "snapshots": []
+    }
+
+    result = json.loads(
+        get_account_snapshots_by_type(start_date="2025-01-01", timeframe="month")
+    )
+
+    mock_monarch_client.get_account_snapshots_by_type.assert_called_once_with(
+        "2025-01-01", "month"
+    )
+
+
+def test_snapshots_by_type_year(mock_monarch_client):
+    mock_monarch_client.get_account_snapshots_by_type.return_value = {
+        "snapshots": []
+    }
+
+    get_account_snapshots_by_type(start_date="2020-01-01", timeframe="year")
+
+    mock_monarch_client.get_account_snapshots_by_type.assert_called_once_with(
+        "2020-01-01", "year"
+    )
+
+
+def test_snapshots_by_type_invalid_timeframe():
+    result = json.loads(
+        get_account_snapshots_by_type(start_date="2025-01-01", timeframe="week")
+    )
+    assert "error" in result
+
+
+# ===================================================================
+# get_aggregate_snapshots
+# ===================================================================
+
+
+def test_aggregate_snapshots_no_params(mock_monarch_client):
+    mock_monarch_client.get_aggregate_snapshots.return_value = {"snapshots": []}
+
+    result = json.loads(get_aggregate_snapshots())
+
+    mock_monarch_client.get_aggregate_snapshots.assert_called_once_with()
+
+
+def test_aggregate_snapshots_with_dates(mock_monarch_client):
+    mock_monarch_client.get_aggregate_snapshots.return_value = {"snapshots": []}
+
+    get_aggregate_snapshots(start_date="2025-01-01", end_date="2025-12-31")
+
+    from datetime import date
+    mock_monarch_client.get_aggregate_snapshots.assert_called_once_with(
+        start_date=date(2025, 1, 1), end_date=date(2025, 12, 31)
+    )
+
+
+def test_aggregate_snapshots_with_type(mock_monarch_client):
+    mock_monarch_client.get_aggregate_snapshots.return_value = {"snapshots": []}
+
+    get_aggregate_snapshots(account_type="depository")
+
+    mock_monarch_client.get_aggregate_snapshots.assert_called_once_with(
+        account_type="depository"
+    )
+
+
+# ===================================================================
+# get_account_type_options
+# ===================================================================
+
+
+def test_account_type_options_happy(mock_monarch_client):
+    mock_monarch_client.get_account_type_options.return_value = {
+        "accountTypeOptions": [
+            {"type": "depository", "subTypes": ["checking", "savings"]},
+        ]
+    }
+
+    result = json.loads(get_account_type_options())
+
+    assert len(result["accountTypeOptions"]) == 1
+    mock_monarch_client.get_account_type_options.assert_called_once()
+
+
+# ===================================================================
+# get_credit_history
+# ===================================================================
+
+
+def test_credit_history_happy(mock_monarch_client):
+    mock_monarch_client.get_credit_history.return_value = {
+        "creditHistory": [{"date": "2025-01-01", "score": 750}]
+    }
+
+    result = json.loads(get_credit_history())
+
+    assert result["creditHistory"][0]["score"] == 750
+    mock_monarch_client.get_credit_history.assert_called_once()
+
+
+def test_credit_history_empty(mock_monarch_client):
+    mock_monarch_client.get_credit_history.return_value = {"creditHistory": []}
+
+    result = json.loads(get_credit_history())
+
+    assert result["creditHistory"] == []

--- a/tests/test_account_management.py
+++ b/tests/test_account_management.py
@@ -157,6 +157,7 @@ def test_delete_account_happy(mock_monarch_client):
 
     assert result["deleted"] is True
     assert result["account_id"] == "acc-1"
+    assert result["result"] is None
     mock_monarch_client.delete_account.assert_called_once_with("acc-1")
 
 

--- a/tests/test_budget_set.py
+++ b/tests/test_budget_set.py
@@ -1,0 +1,84 @@
+"""Tests for set_budget_amount tool."""
+# pylint: disable=missing-function-docstring
+
+import json
+
+from monarch_mcp_server.server import set_budget_amount
+
+
+def test_set_budget_with_category(mock_monarch_client):
+    mock_monarch_client.set_budget_amount.return_value = {
+        "updateOrCreateBudgetItem": {"id": "budget-1"}
+    }
+
+    result = json.loads(set_budget_amount(amount=500.0, category_id="cat-1"))
+
+    assert "updateOrCreateBudgetItem" in result
+    mock_monarch_client.set_budget_amount.assert_called_once_with(
+        amount=500.0,
+        timeframe="month",
+        apply_to_future=False,
+        category_id="cat-1",
+    )
+
+
+def test_set_budget_with_group(mock_monarch_client):
+    mock_monarch_client.set_budget_amount.return_value = {
+        "updateOrCreateBudgetItem": {"id": "budget-2"}
+    }
+
+    result = json.loads(set_budget_amount(amount=2000.0, category_group_id="grp-1"))
+
+    assert "updateOrCreateBudgetItem" in result
+    mock_monarch_client.set_budget_amount.assert_called_once_with(
+        amount=2000.0,
+        timeframe="month",
+        apply_to_future=False,
+        category_group_id="grp-1",
+    )
+
+
+def test_set_budget_both_ids_error():
+    result = json.loads(
+        set_budget_amount(amount=100.0, category_id="cat-1", category_group_id="grp-1")
+    )
+    assert "error" in result
+    assert "exactly one" in result["error"].lower()
+
+
+def test_set_budget_neither_id_error():
+    result = json.loads(set_budget_amount(amount=100.0))
+    assert "error" in result
+    assert "exactly one" in result["error"].lower()
+
+
+def test_set_budget_apply_to_future(mock_monarch_client):
+    mock_monarch_client.set_budget_amount.return_value = {
+        "updateOrCreateBudgetItem": {"id": "budget-1"}
+    }
+
+    set_budget_amount(amount=300.0, category_id="cat-1", apply_to_future=True)
+
+    call_kwargs = mock_monarch_client.set_budget_amount.call_args[1]
+    assert call_kwargs["apply_to_future"] is True
+
+
+def test_set_budget_with_start_date(mock_monarch_client):
+    mock_monarch_client.set_budget_amount.return_value = {
+        "updateOrCreateBudgetItem": {"id": "budget-1"}
+    }
+
+    set_budget_amount(
+        amount=400.0, category_id="cat-1", start_date="2025-02-01"
+    )
+
+    call_kwargs = mock_monarch_client.set_budget_amount.call_args[1]
+    assert call_kwargs["start_date"] == "2025-02-01"
+
+
+def test_set_budget_error(mock_monarch_client):
+    mock_monarch_client.set_budget_amount.side_effect = Exception("Invalid category")
+
+    result = set_budget_amount(amount=100.0, category_id="bad-cat")
+
+    assert "Error" in result

--- a/tests/test_budgets_cashflow.py
+++ b/tests/test_budgets_cashflow.py
@@ -29,7 +29,7 @@ def test_budgets_both_dates(mock_monarch_client):
 
     assert "budgetData" in result
     mock_monarch_client.get_budgets.assert_called_once_with(
-        start_date="2025-01-01", end_date="2025-01-31"
+        use_v2_goals=True, start_date="2025-01-01", end_date="2025-01-31"
     )
 
 
@@ -39,7 +39,7 @@ def test_budgets_no_dates(mock_monarch_client):
     result = json.loads(get_budgets())
 
     assert "budgetData" in result
-    mock_monarch_client.get_budgets.assert_called_once_with()
+    mock_monarch_client.get_budgets.assert_called_once_with(use_v2_goals=True)
 
 
 def test_budgets_only_start():
@@ -69,6 +69,22 @@ def test_budgets_future_dates(mock_monarch_client):
     )
 
     assert result["budgetData"] is None
+
+
+def test_budgets_v2_goals_default(mock_monarch_client):
+    mock_monarch_client.get_budgets.return_value = SAMPLE_BUDGET
+
+    get_budgets()
+
+    mock_monarch_client.get_budgets.assert_called_once_with(use_v2_goals=True)
+
+
+def test_budgets_v2_goals_disabled(mock_monarch_client):
+    mock_monarch_client.get_budgets.return_value = SAMPLE_BUDGET
+
+    get_budgets(use_v2_goals=False)
+
+    mock_monarch_client.get_budgets.assert_called_once_with(use_v2_goals=False)
 
 
 # ===================================================================

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -172,6 +172,7 @@ def test_delete_category_happy(mock_monarch_client):
 
     assert result["deleted"] is True
     assert result["category_id"] == "cat-1"
+    assert result["result"] is True
     mock_monarch_client.delete_transaction_category.assert_called_once_with("cat-1")
 
 

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -1,0 +1,185 @@
+"""Tests for transaction category tools."""
+# pylint: disable=missing-function-docstring
+
+import json
+from datetime import datetime
+
+from monarch_mcp_server.server import (
+    get_transaction_categories,
+    get_transaction_category_groups,
+    create_transaction_category,
+    delete_transaction_category,
+)
+
+
+SAMPLE_CATEGORIES = {
+    "categories": [
+        {
+            "id": "cat-1",
+            "name": "Groceries",
+            "order": 0,
+            "isSystemCategory": False,
+            "isDisabled": False,
+            "group": {"id": "grp-1", "name": "Food & Drink", "type": "expense"},
+        },
+        {
+            "id": "cat-2",
+            "name": "Salary",
+            "order": 0,
+            "isSystemCategory": True,
+            "isDisabled": False,
+            "group": {"id": "grp-2", "name": "Income", "type": "income"},
+        },
+    ]
+}
+
+SAMPLE_GROUPS = {
+    "categoryGroups": [
+        {"id": "grp-1", "name": "Food & Drink", "order": 0, "type": "expense"},
+        {"id": "grp-2", "name": "Income", "order": 1, "type": "income"},
+    ]
+}
+
+
+# ===================================================================
+# get_transaction_categories
+# ===================================================================
+
+
+def test_get_categories_happy(mock_monarch_client):
+    mock_monarch_client.get_transaction_categories.return_value = SAMPLE_CATEGORIES
+
+    result = json.loads(get_transaction_categories())
+
+    assert len(result["categories"]) == 2
+    assert result["categories"][0]["name"] == "Groceries"
+    mock_monarch_client.get_transaction_categories.assert_called_once()
+
+
+def test_get_categories_empty(mock_monarch_client):
+    mock_monarch_client.get_transaction_categories.return_value = {"categories": []}
+
+    result = json.loads(get_transaction_categories())
+
+    assert result["categories"] == []
+
+
+def test_get_categories_error(mock_monarch_client):
+    mock_monarch_client.get_transaction_categories.side_effect = Exception("API down")
+
+    result = get_transaction_categories()
+
+    assert "Error" in result
+
+
+# ===================================================================
+# get_transaction_category_groups
+# ===================================================================
+
+
+def test_get_category_groups_happy(mock_monarch_client):
+    mock_monarch_client.get_transaction_category_groups.return_value = SAMPLE_GROUPS
+
+    result = json.loads(get_transaction_category_groups())
+
+    assert len(result["categoryGroups"]) == 2
+    mock_monarch_client.get_transaction_category_groups.assert_called_once()
+
+
+def test_get_category_groups_empty(mock_monarch_client):
+    mock_monarch_client.get_transaction_category_groups.return_value = {
+        "categoryGroups": []
+    }
+
+    result = json.loads(get_transaction_category_groups())
+
+    assert result["categoryGroups"] == []
+
+
+# ===================================================================
+# create_transaction_category
+# ===================================================================
+
+
+def test_create_category_happy(mock_monarch_client):
+    mock_monarch_client.create_transaction_category.return_value = {
+        "id": "cat-new",
+        "name": "Coffee",
+    }
+
+    result = json.loads(create_transaction_category(group_id="grp-1", name="Coffee"))
+
+    assert result["name"] == "Coffee"
+    call_kwargs = mock_monarch_client.create_transaction_category.call_args[1]
+    assert call_kwargs["group_id"] == "grp-1"
+    assert call_kwargs["transaction_category_name"] == "Coffee"
+    assert call_kwargs["icon"] == "\u2753"
+    assert call_kwargs["rollover_enabled"] is False
+
+
+def test_create_category_with_rollover(mock_monarch_client):
+    mock_monarch_client.create_transaction_category.return_value = {
+        "id": "cat-new",
+        "name": "Rent",
+    }
+
+    result = json.loads(
+        create_transaction_category(
+            group_id="grp-1",
+            name="Rent",
+            rollover_enabled=True,
+            rollover_start_month="2025-01-01",
+        )
+    )
+
+    assert result["name"] == "Rent"
+    call_kwargs = mock_monarch_client.create_transaction_category.call_args[1]
+    assert call_kwargs["rollover_enabled"] is True
+    assert call_kwargs["rollover_start_month"] == datetime(2025, 1, 1)
+
+
+def test_create_category_custom_icon(mock_monarch_client):
+    mock_monarch_client.create_transaction_category.return_value = {
+        "id": "cat-new",
+        "name": "Gaming",
+    }
+
+    create_transaction_category(group_id="grp-1", name="Gaming", icon="\U0001F3AE")
+
+    call_kwargs = mock_monarch_client.create_transaction_category.call_args[1]
+    assert call_kwargs["icon"] == "\U0001F3AE"
+
+
+def test_create_category_error(mock_monarch_client):
+    mock_monarch_client.create_transaction_category.side_effect = Exception(
+        "Group not found"
+    )
+
+    result = create_transaction_category(group_id="bad-grp", name="Test")
+
+    assert "Error" in result
+
+
+# ===================================================================
+# delete_transaction_category
+# ===================================================================
+
+
+def test_delete_category_happy(mock_monarch_client):
+    mock_monarch_client.delete_transaction_category.return_value = True
+
+    result = json.loads(delete_transaction_category(category_id="cat-1"))
+
+    assert result["deleted"] is True
+    assert result["category_id"] == "cat-1"
+    mock_monarch_client.delete_transaction_category.assert_called_once_with("cat-1")
+
+
+def test_delete_category_error(mock_monarch_client):
+    mock_monarch_client.delete_transaction_category.side_effect = Exception(
+        "Category not found"
+    )
+
+    result = delete_transaction_category(category_id="bad-cat")
+
+    assert "Error" in result

--- a/tests/test_read_tools.py
+++ b/tests/test_read_tools.py
@@ -1,0 +1,191 @@
+"""Tests for simple read-only tools: summary, subscription, institutions, cashflow_summary."""
+# pylint: disable=missing-function-docstring
+
+import json
+
+from monarch_mcp_server.server import (
+    get_transactions_summary,
+    get_subscription_details,
+    get_institutions,
+    get_cashflow_summary,
+)
+
+
+# ===================================================================
+# get_transactions_summary
+# ===================================================================
+
+
+SAMPLE_SUMMARY = {
+    "allTransactions": {
+        "totalCount": 500,
+        "results": [],
+    },
+    "transactionsSummary": {
+        "avg": -45.50,
+        "count": 500,
+        "max": 5000.00,
+        "maxExpense": -2500.00,
+        "sum": -22750.00,
+        "sumIncome": 12000.00,
+        "sumExpense": -34750.00,
+    },
+}
+
+
+def test_summary_happy(mock_monarch_client):
+    mock_monarch_client.get_transactions_summary.return_value = SAMPLE_SUMMARY
+
+    result = json.loads(get_transactions_summary())
+
+    assert "transactionsSummary" in result
+    mock_monarch_client.get_transactions_summary.assert_called_once()
+
+
+def test_summary_error(mock_monarch_client):
+    mock_monarch_client.get_transactions_summary.side_effect = Exception("API down")
+
+    result = get_transactions_summary()
+
+    assert "Error" in result
+
+
+# ===================================================================
+# get_subscription_details
+# ===================================================================
+
+
+SAMPLE_SUBSCRIPTION = {
+    "subscription": {
+        "id": "sub-1",
+        "paymentSource": "stripe",
+        "referralCode": "ABC123",
+        "isOnFreeTrial": False,
+        "hasPremiumEntitlement": True,
+    }
+}
+
+
+def test_subscription_happy(mock_monarch_client):
+    mock_monarch_client.get_subscription_details.return_value = SAMPLE_SUBSCRIPTION
+
+    result = json.loads(get_subscription_details())
+
+    assert result["subscription"]["hasPremiumEntitlement"] is True
+    mock_monarch_client.get_subscription_details.assert_called_once()
+
+
+def test_subscription_error(mock_monarch_client):
+    mock_monarch_client.get_subscription_details.side_effect = Exception("API down")
+
+    result = get_subscription_details()
+
+    assert "Error" in result
+
+
+# ===================================================================
+# get_institutions
+# ===================================================================
+
+
+SAMPLE_INSTITUTIONS = {
+    "credentials": [
+        {
+            "id": "cred-1",
+            "institution": {"name": "Chase", "status": "GOOD"},
+            "accounts": [
+                {"id": "acc-1", "displayName": "Checking"},
+            ],
+        }
+    ]
+}
+
+
+def test_institutions_happy(mock_monarch_client):
+    mock_monarch_client.get_institutions.return_value = SAMPLE_INSTITUTIONS
+
+    result = json.loads(get_institutions())
+
+    assert len(result["credentials"]) == 1
+    assert result["credentials"][0]["institution"]["name"] == "Chase"
+    mock_monarch_client.get_institutions.assert_called_once()
+
+
+def test_institutions_empty(mock_monarch_client):
+    mock_monarch_client.get_institutions.return_value = {"credentials": []}
+
+    result = json.loads(get_institutions())
+
+    assert result["credentials"] == []
+
+
+def test_institutions_error(mock_monarch_client):
+    mock_monarch_client.get_institutions.side_effect = Exception("API down")
+
+    result = get_institutions()
+
+    assert "Error" in result
+
+
+# ===================================================================
+# get_cashflow_summary
+# ===================================================================
+
+
+SAMPLE_CASHFLOW_SUMMARY = {
+    "summary": [
+        {
+            "summary": {
+                "sumIncome": 6000,
+                "sumExpense": -4000,
+                "savings": 2000,
+                "savingsRate": 0.33,
+            }
+        }
+    ]
+}
+
+
+def test_cashflow_summary_no_dates(mock_monarch_client):
+    mock_monarch_client.get_cashflow_summary.return_value = SAMPLE_CASHFLOW_SUMMARY
+
+    result = json.loads(get_cashflow_summary())
+
+    assert "summary" in result
+    mock_monarch_client.get_cashflow_summary.assert_called_once_with(limit=100)
+
+
+def test_cashflow_summary_with_dates(mock_monarch_client):
+    mock_monarch_client.get_cashflow_summary.return_value = SAMPLE_CASHFLOW_SUMMARY
+
+    get_cashflow_summary(start_date="2025-01-01", end_date="2025-01-31")
+
+    mock_monarch_client.get_cashflow_summary.assert_called_once_with(
+        limit=100, start_date="2025-01-01", end_date="2025-01-31"
+    )
+
+
+def test_cashflow_summary_custom_limit(mock_monarch_client):
+    mock_monarch_client.get_cashflow_summary.return_value = SAMPLE_CASHFLOW_SUMMARY
+
+    get_cashflow_summary(limit=50)
+
+    mock_monarch_client.get_cashflow_summary.assert_called_once_with(limit=50)
+
+
+def test_cashflow_summary_only_start_error():
+    result = json.loads(get_cashflow_summary(start_date="2025-01-01"))
+    assert "error" in result
+
+
+def test_cashflow_summary_only_end_error():
+    result = json.loads(get_cashflow_summary(end_date="2025-01-31"))
+    assert "error" in result
+
+
+def test_cashflow_summary_error(mock_monarch_client):
+    mock_monarch_client.get_cashflow_summary.side_effect = Exception("API down")
+
+    result = get_cashflow_summary()
+
+    assert "Error" in result

--- a/tests/test_recurring.py
+++ b/tests/test_recurring.py
@@ -1,0 +1,75 @@
+"""Tests for get_recurring_transactions tool."""
+# pylint: disable=missing-function-docstring
+
+import json
+
+from monarch_mcp_server.server import get_recurring_transactions
+
+
+SAMPLE_RECURRING = {
+    "recurringTransactions": [
+        {
+            "id": "rec-1",
+            "amount": -15.99,
+            "merchant": {"name": "Netflix"},
+            "frequency": "monthly",
+            "account": {"displayName": "Checking"},
+            "category": {"name": "Entertainment"},
+        },
+        {
+            "id": "rec-2",
+            "amount": -1200.00,
+            "merchant": {"name": "Landlord"},
+            "frequency": "monthly",
+            "account": {"displayName": "Checking"},
+            "category": {"name": "Housing"},
+        },
+    ]
+}
+
+
+def test_recurring_no_dates(mock_monarch_client):
+    mock_monarch_client.get_recurring_transactions.return_value = SAMPLE_RECURRING
+
+    result = json.loads(get_recurring_transactions())
+
+    assert len(result["recurringTransactions"]) == 2
+    mock_monarch_client.get_recurring_transactions.assert_called_once_with()
+
+
+def test_recurring_with_dates(mock_monarch_client):
+    mock_monarch_client.get_recurring_transactions.return_value = SAMPLE_RECURRING
+
+    get_recurring_transactions(start_date="2025-01-01", end_date="2025-12-31")
+
+    mock_monarch_client.get_recurring_transactions.assert_called_once_with(
+        start_date="2025-01-01", end_date="2025-12-31"
+    )
+
+
+def test_recurring_only_start_error():
+    result = json.loads(get_recurring_transactions(start_date="2025-01-01"))
+    assert "error" in result
+
+
+def test_recurring_only_end_error():
+    result = json.loads(get_recurring_transactions(end_date="2025-12-31"))
+    assert "error" in result
+
+
+def test_recurring_empty(mock_monarch_client):
+    mock_monarch_client.get_recurring_transactions.return_value = {
+        "recurringTransactions": []
+    }
+
+    result = json.loads(get_recurring_transactions())
+
+    assert result["recurringTransactions"] == []
+
+
+def test_recurring_error(mock_monarch_client):
+    mock_monarch_client.get_recurring_transactions.side_effect = Exception("API down")
+
+    result = get_recurring_transactions()
+
+    assert "Error" in result

--- a/tests/test_transaction_crud.py
+++ b/tests/test_transaction_crud.py
@@ -57,6 +57,7 @@ def test_create_happy(mock_monarch_client):
         merchant_name="Coffee Shop",
         category_id="cat-1",
         notes="Morning coffee",
+        update_balance=False,
     )
 
 
@@ -190,6 +191,37 @@ def test_create_unicode_merchant(mock_monarch_client):
     )
 
     assert result["merchant"]["name"] == name
+
+
+def test_create_with_update_balance(mock_monarch_client):
+    mock_monarch_client.create_transaction.return_value = _api_txn()
+
+    create_transaction(
+        account_id="acc-1",
+        amount=-42.50,
+        merchant_name="Coffee Shop",
+        category_id="cat-1",
+        date="2025-01-15",
+        update_balance=True,
+    )
+
+    call_kwargs = mock_monarch_client.create_transaction.call_args[1]
+    assert call_kwargs["update_balance"] is True
+
+
+def test_create_default_update_balance(mock_monarch_client):
+    mock_monarch_client.create_transaction.return_value = _api_txn()
+
+    create_transaction(
+        account_id="acc-1",
+        amount=-10.0,
+        merchant_name="Store",
+        category_id="cat-1",
+        date="2025-01-15",
+    )
+
+    call_kwargs = mock_monarch_client.create_transaction.call_args[1]
+    assert call_kwargs["update_balance"] is False
 
 
 # ===================================================================

--- a/tests/test_transaction_splits.py
+++ b/tests/test_transaction_splits.py
@@ -1,0 +1,102 @@
+"""Tests for transaction split tools."""
+# pylint: disable=missing-function-docstring
+
+import json
+
+from monarch_mcp_server.server import get_transaction_splits, update_transaction_splits
+
+
+SAMPLE_SPLITS = {
+    "getTransaction": {
+        "id": "txn-1",
+        "splitTransactions": [
+            {"id": "split-1", "amount": -60.0, "merchant": {"name": "Store A"}},
+            {"id": "split-2", "amount": -40.0, "merchant": {"name": "Store B"}},
+        ],
+    }
+}
+
+
+# ===================================================================
+# get_transaction_splits
+# ===================================================================
+
+
+def test_get_splits_happy(mock_monarch_client):
+    mock_monarch_client.get_transaction_splits.return_value = SAMPLE_SPLITS
+
+    result = json.loads(get_transaction_splits(transaction_id="txn-1"))
+
+    splits = result["getTransaction"]["splitTransactions"]
+    assert len(splits) == 2
+    mock_monarch_client.get_transaction_splits.assert_called_once_with("txn-1")
+
+
+def test_get_splits_empty(mock_monarch_client):
+    mock_monarch_client.get_transaction_splits.return_value = {
+        "getTransaction": {"id": "txn-1", "splitTransactions": []}
+    }
+
+    result = json.loads(get_transaction_splits(transaction_id="txn-1"))
+
+    assert result["getTransaction"]["splitTransactions"] == []
+
+
+def test_get_splits_error(mock_monarch_client):
+    mock_monarch_client.get_transaction_splits.side_effect = Exception(
+        "Transaction not found"
+    )
+
+    result = get_transaction_splits(transaction_id="bad-id")
+
+    assert "Error" in result
+
+
+# ===================================================================
+# update_transaction_splits
+# ===================================================================
+
+
+def test_update_splits_happy(mock_monarch_client):
+    mock_monarch_client.update_transaction_splits.return_value = {
+        "updateTransactionSplits": {"id": "txn-1"}
+    }
+
+    split_data = [
+        {"merchantName": "Store A", "amount": -60.0, "categoryId": "cat-1"},
+        {"merchantName": "Store B", "amount": -40.0, "categoryId": "cat-2"},
+    ]
+    result = json.loads(
+        update_transaction_splits(transaction_id="txn-1", split_data=split_data)
+    )
+
+    assert "updateTransactionSplits" in result
+    mock_monarch_client.update_transaction_splits.assert_called_once_with(
+        "txn-1", split_data
+    )
+
+
+def test_update_splits_remove_all(mock_monarch_client):
+    mock_monarch_client.update_transaction_splits.return_value = {
+        "updateTransactionSplits": {"id": "txn-1"}
+    }
+
+    result = json.loads(
+        update_transaction_splits(transaction_id="txn-1", split_data=[])
+    )
+
+    assert "updateTransactionSplits" in result
+    mock_monarch_client.update_transaction_splits.assert_called_once_with("txn-1", [])
+
+
+def test_update_splits_error(mock_monarch_client):
+    mock_monarch_client.update_transaction_splits.side_effect = Exception(
+        "Split amounts don't match"
+    )
+
+    result = update_transaction_splits(
+        transaction_id="txn-1",
+        split_data=[{"merchantName": "X", "amount": -50.0, "categoryId": "cat-1"}],
+    )
+
+    assert "Error" in result

--- a/tests/test_transactions_read.py
+++ b/tests/test_transactions_read.py
@@ -242,3 +242,132 @@ def test_future_dates_empty(mock_monarch_client):
     )
 
     assert result == []
+
+
+# ---------------------------------------------------------------------------
+# 3.15 – search filter
+# ---------------------------------------------------------------------------
+
+
+def test_search_filter(mock_monarch_client):
+    mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
+
+    get_transactions(search="coffee")
+
+    mock_monarch_client.get_transactions.assert_called_once_with(
+        limit=100, offset=0, search="coffee"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3.16 – category_ids filter
+# ---------------------------------------------------------------------------
+
+
+def test_category_ids_filter(mock_monarch_client):
+    mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
+
+    get_transactions(category_ids=["cat-1", "cat-2"])
+
+    mock_monarch_client.get_transactions.assert_called_once_with(
+        limit=100, offset=0, category_ids=["cat-1", "cat-2"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3.17 – account_ids list filter
+# ---------------------------------------------------------------------------
+
+
+def test_account_ids_filter(mock_monarch_client):
+    mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
+
+    get_transactions(account_ids=["acc-1", "acc-2"])
+
+    mock_monarch_client.get_transactions.assert_called_once_with(
+        limit=100, offset=0, account_ids=["acc-1", "acc-2"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3.18 – account_id + account_ids conflict -> error
+# ---------------------------------------------------------------------------
+
+
+def test_account_id_and_account_ids_conflict():
+    result = json.loads(
+        get_transactions(account_id="acc-1", account_ids=["acc-2"])
+    )
+    assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# 3.19 – tag_ids filter
+# ---------------------------------------------------------------------------
+
+
+def test_tag_ids_filter(mock_monarch_client):
+    mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
+
+    get_transactions(tag_ids=["tag-1"])
+
+    mock_monarch_client.get_transactions.assert_called_once_with(
+        limit=100, offset=0, tag_ids=["tag-1"]
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3.20 – boolean filters
+# ---------------------------------------------------------------------------
+
+
+def test_bool_filters(mock_monarch_client):
+    mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
+
+    get_transactions(has_notes=True, is_recurring=False)
+
+    mock_monarch_client.get_transactions.assert_called_once_with(
+        limit=100, offset=0, has_notes=True, is_recurring=False
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3.21 – hidden_from_reports filter
+# ---------------------------------------------------------------------------
+
+
+def test_hidden_from_reports_filter(mock_monarch_client):
+    mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
+
+    get_transactions(hidden_from_reports=True)
+
+    mock_monarch_client.get_transactions.assert_called_once_with(
+        limit=100, offset=0, hidden_from_reports=True
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3.22 – combined search and filters
+# ---------------------------------------------------------------------------
+
+
+def test_combined_search_and_filters(mock_monarch_client):
+    mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
+
+    get_transactions(
+        search="grocery",
+        category_ids=["cat-1"],
+        start_date="2025-01-01",
+        end_date="2025-01-31",
+        is_split=False,
+    )
+
+    mock_monarch_client.get_transactions.assert_called_once_with(
+        limit=100,
+        offset=0,
+        start_date="2025-01-01",
+        end_date="2025-01-31",
+        search="grocery",
+        category_ids=["cat-1"],
+        is_split=False,
+    )


### PR DESCRIPTION
## Summary

- Analyzed the `monarchmoney` Python library (v1.3.0) against the MCP server and implemented all practical missing features
- **Tool count: 17 → 39** (+22 new tools, 3 existing enhanced)
- **Tests: 49 → 229** all passing, pylint 10.00/10

### Enhanced existing tools
- `get_transactions`: 10 new filter params (search, category_ids, tag_ids, boolean filters)
- `create_transaction`: added `update_balance` parameter
- `get_budgets`: added `use_v2_goals` parameter

### New read-only tools (8)
`get_transaction_categories`, `get_transaction_category_groups`, `get_transaction_details`, `get_recurring_transactions`, `get_transactions_summary`, `get_subscription_details`, `get_institutions`, `get_cashflow_summary`

### New mutation tools (7)
`set_budget_amount`, `get/update_transaction_splits`, `create/delete_transaction_category`, `create_manual_account`, `update_account`

### New analytics/history tools (7)
`get_account_history`, `get_recent_account_balances`, `get_account_snapshots_by_type`, `get_aggregate_snapshots`, `get_account_type_options`, `get_credit_history`, `delete_account`

### Skipped (impractical for MCP)
`upload_account_balance_history`, `upload_attachment`, `request_accounts_refresh_and_wait`, `delete_transaction_categories` (batch)

## Test plan
- [x] All 229 unit tests pass (`py -m pytest tests/`)
- [x] Pylint 10.00/10 (`py -m pylint src/monarch_mcp_server/`)
- [ ] Run integration skill (`/test-monarch-mcp`) to verify live API behavior
- [ ] Restart Claude Desktop and verify new tools appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)