### PR TITLE
Add read-only mode and migrate to fastmcp

### DIFF
--- a/.claude/skills/test-monarch-mcp/SKILL.md
+++ b/.claude/skills/test-monarch-mcp/SKILL.md
@@ -11,6 +11,15 @@ Run all 127 tests across 12 phases, track results, and clean up after yourself.
 
 ---
 
+## Write Mode Requirement
+
+This test suite creates, updates, and deletes data. The server must be running
+with **write tools enabled** (`--enable-write`). When running against the MCP
+tools directly (as this skill does), write mode is required — otherwise the 13
+write tools will be hidden and the mutation phases will fail.
+
+---
+
 ## State File Management
 
 The state file is `mcp-test-state.json` in the project root (`C:\dev\monarch-mcp\monarch-mcp-server\mcp-test-state.json`).

--- a/.claude/skills/test-monarch-mcp/SKILL.md
+++ b/.claude/skills/test-monarch-mcp/SKILL.md
@@ -1,22 +1,22 @@
 ---
 name: test-monarch-mcp
-description: Systematically test all 39 Monarch Money MCP tools — happy paths, edge cases, and error handling. Account-agnostic (discovers IDs at runtime) and self-cleaning (deletes everything it creates).
+description: Systematically test Monarch Money MCP tools in read-only mode (26 tools, 63 tests) or write-enabled mode (all 39 tools, 127 tests). Account-agnostic (discovers IDs at runtime) and self-cleaning (deletes everything it creates in write mode).
 user_invocable: true
 ---
 
 # Test Monarch MCP Skill
 
 You are executing a comprehensive test suite for the Monarch Money MCP server.
-Run all 127 tests across 12 phases, track results, and clean up after yourself.
+Run tests across 12 phases, track results, and clean up after yourself.
 
 ---
 
-## Write Mode Requirement
+## Mode Support
 
-This test suite creates, updates, and deletes data. The server must be running
-with **write tools enabled** (`--enable-write`). When running against the MCP
-tools directly (as this skill does), write mode is required — otherwise the 13
-write tools will be hidden and the mutation phases will fail.
+This test suite supports two modes, auto-detected at startup:
+
+- **Read-only mode** (default): Tests 26 read-only tools (63 tests). Write-dependent tests are skipped. No data is created, modified, or deleted.
+- **Write-enabled mode** (`--enable-write`): Tests all 39 tools (127 tests). Creates, modifies, and deletes data on your live Monarch account. Self-cleaning.
 
 ---
 
@@ -40,6 +40,7 @@ The state file is `mcp-test-state.json` in the project root (`C:\dev\monarch-mcp
 ```json
 {
   "status": "in_progress | completed | cleanup_needed",
+  "mode": "read-only | read-write",
   "started_at": "<ISO timestamp>",
   "last_updated": "<ISO timestamp>",
   "last_completed_phase": 0,
@@ -74,6 +75,9 @@ The state file is `mcp-test-state.json` in the project root (`C:\dev\monarch-mcp
 }
 ```
 
+In **read-only mode**, `summary.total` is `63` and `original_values` is omitted (no mutations will happen).
+In **write-enabled mode**, `summary.total` is `127`.
+
 ### Update Cadence
 
 - **Write** the state file after Phase 0 (discovery IDs are now logged).
@@ -92,13 +96,39 @@ The state file is `mcp-test-state.json` in the project root (`C:\dev\monarch-mcp
 
 ---
 
-## Pre-flight Warning
+## Pre-flight: Auto-detect Mode & Confirm
 
-Before starting any test work (including Phase 0), display this warning and **STOP and wait for explicit user approval**:
+Before starting any test work (including Phase 0), detect the server mode and get user confirmation.
+
+### Mode Detection (Phase 0 preamble)
+
+Check which MCP tools are available. If write tools like `create_transaction`, `create_transaction_tag`, `delete_transaction`, etc. are available, the server is in **read-write mode**. If they are absent, the server is in **read-only mode**.
+
+### User Confirmation
+
+Based on the detected mode, display the appropriate message and **STOP and wait for explicit user approval**:
+
+#### If read-only mode detected:
 
 ---
 
-**WARNING: This test suite operates on your live Monarch Money account.**
+**Server is running in read-only mode (26 tools).**
+
+I'll run 63 read-only tests and skip 64 write tests. No data will be created, modified, or deleted on your Monarch account.
+
+To test all 127 tools, disable `monarch-money-read-only` and enable `monarch-money` in `.mcp.json`, then restart.
+
+**Proceed with read-only tests?**
+
+---
+
+#### If read-write mode detected:
+
+---
+
+**WARNING: Server is running in read-write mode (all 39 tools).**
+
+I'll run all 127 tests. This will **create, modify, and delete** data on your **live Monarch Money account**:
 
 - It **creates and deletes** transactions, tags, categories, and accounts.
 - It **temporarily modifies** an existing transaction (then reverts it).
@@ -106,13 +136,15 @@ Before starting any test work (including Phase 0), display this warning and **ST
 - All test-created data is prefixed with `MCP-Test-` for easy manual identification.
 - If the session is interrupted, you can **resume where you left off** by invoking this skill again — it will detect the saved progress and offer to continue.
 
+To test read-only mode only, disable `monarch-money` and enable `monarch-money-read-only` in `.mcp.json`, then restart.
+
 **Do you want to continue?**
 
 ---
 
 Do NOT proceed until the user explicitly confirms. If the user declines, stop immediately.
 
-This warning applies to **fresh runs only**. When resuming an in-progress run or performing cleanup-only, skip this warning (the user already accepted the risk).
+This confirmation applies to **fresh runs only**. When resuming an in-progress run or performing cleanup-only, skip this confirmation (the user already accepted the risk).
 
 ---
 
@@ -127,15 +159,16 @@ This phase runs first. No reference file — execute inline.
 2. Call `get_transactions(limit=5)`.
    - Extract `test_transaction_id`: the first transaction's ID.
    - Extract `valid_category_id`: the first transaction's category ID.
-   - Record **original values** for the test transaction: `merchant` (or `merchant_name`), `notes`, `amount`, `date`, `category_id`, `hide_from_reports`, `needs_review`.
+   - **Write mode only:** Record **original values** for the test transaction: `merchant` (or `merchant_name`), `notes`, `amount`, `date`, `category_id`, `hide_from_reports`, `needs_review`.
 
-3. Initialize `created_resources = { transactions: [], tags: [] }`.
+3. Initialize `created_resources = { transactions: [], tags: [], categories: [], accounts: [] }`.
 
-4. Write the state file with `status: "in_progress"`, `last_completed_phase: 0`.
+4. Record detected `mode` in state file. Write the state file with `status: "in_progress"`, `last_completed_phase: 0`.
 
 5. Print discovery results:
    ```
    === Phase 0: Discovery ===
+   Mode:                {read-only | read-write}
    Checking account:    {id} ({name})
    Investment account:  {id} ({name}) or "None found"
    Test transaction:    {id} ({merchant}, ${amount})
@@ -178,6 +211,8 @@ After completing all tests, update state file: `last_completed_phase: 3`, add re
 
 Load and follow: `references/budgets-and-cashflow.md`
 
+**Read-only mode:** Run tests 4.1-4.12 only (12 tests). Skip 4.13-4.15 (set_budget_amount requires write mode).
+
 After completing all tests, update state file: `last_completed_phase: 4`, add results.
 
 ---
@@ -185,6 +220,8 @@ After completing all tests, update state file: `last_completed_phase: 4`, add re
 ## Phase 5 — Tag CRUD (13 tests)
 
 Load and follow: `references/tag-crud.md`
+
+**Read-only mode:** Run test 5.1 only (1 test). Skip 5.2-5.13 (create/delete tag requires write mode).
 
 **Important:** Track every created tag ID in `created_resources.tags` immediately after creation.
 
@@ -195,6 +232,8 @@ After completing all tests, update state file: `last_completed_phase: 5`, add re
 ## Phase 6 — Transaction CRUD (25 tests)
 
 Load and follow: `references/transaction-crud.md`
+
+**Read-only mode:** Skip entire phase (0 tests). All tests require write tools.
 
 Uses `checking_account_id`, `valid_category_id`, and `test_transaction_id` from discovery.
 
@@ -208,6 +247,8 @@ After completing all tests, update state file: `last_completed_phase: 6`, add re
 
 Load and follow: `references/transaction-tagging.md`
 
+**Read-only mode:** Skip entire phase (0 tests). All tests require write tools.
+
 This phase creates its own temporary tag(s) for testing. Track them in `created_resources.tags`.
 
 After completing all tests, update state file: `last_completed_phase: 7`, add results.
@@ -217,6 +258,8 @@ After completing all tests, update state file: `last_completed_phase: 7`, add re
 ## Phase 8 — Categories (10 tests)
 
 Load and follow: `references/categories.md`
+
+**Read-only mode:** Run tests 8.1-8.3 only (3 tests). Skip 8.4-8.10 (create/delete category requires write mode).
 
 Tests `get_transaction_categories`, `get_transaction_category_groups`, `create_transaction_category`, and `delete_transaction_category`.
 
@@ -229,6 +272,8 @@ After completing all tests, update state file: `last_completed_phase: 8`, add re
 ## Phase 9 — Transaction Details & Splits (8 tests)
 
 Load and follow: `references/transaction-details-and-splits.md`
+
+**Read-only mode:** Run tests 9.1-9.5 only (5 tests). Skip 9.6-9.8 (update_transaction_splits and create_transaction require write mode).
 
 Tests `get_transaction_details`, `get_transaction_splits`, and `update_transaction_splits`.
 
@@ -250,6 +295,8 @@ After completing all tests, update state file: `last_completed_phase: 10`, add r
 
 Load and follow: `references/account-management.md`
 
+**Read-only mode:** Run tests 11.1, 11.6-alt, 11.7-11.10 (6 tests). Skip 11.2-11.6 (create/update/delete account requires write mode). Test 11.6-alt uses `{checking_account_id}` instead of `{created_account_id}`.
+
 Tests `create_manual_account`, `update_account`, `delete_account`, `get_account_type_options`, `get_account_history`, `get_recent_account_balances`, `get_account_snapshots_by_type`, `get_aggregate_snapshots`.
 
 **Important:** Track every created account ID in `created_resources.accounts` immediately after creation.
@@ -270,9 +317,15 @@ After completing all tests, update state file: `last_completed_phase: 12`, add r
 
 ## Cleanup Phase
 
+### Read-only mode
+
+Skip cleanup entirely — no resources were created and no mutations were made. Set `status: "completed"` in state file, then delete `mcp-test-state.json`.
+
+### Write mode
+
 **This phase ALWAYS runs**, even if earlier phases failed or were skipped.
 
-### Step 1: Revert Test Transaction Mutations
+#### Step 1: Revert Test Transaction Mutations
 
 Using `test_transaction_id` and `original_values` from state file:
 
@@ -289,7 +342,7 @@ update_transaction(
 )
 ```
 
-### Step 2: Remove Tags from Test Transaction
+#### Step 2: Remove Tags from Test Transaction
 
 ```
 set_transaction_tags(
@@ -298,7 +351,7 @@ set_transaction_tags(
 )
 ```
 
-### Step 3: Delete Created Transactions
+#### Step 3: Delete Created Transactions
 
 For each ID in `created_resources.transactions`:
 ```
@@ -306,7 +359,7 @@ delete_transaction(transaction_id = {id})
 ```
 Log success/failure for each. Continue on failure.
 
-### Step 4: Delete Created Tags
+#### Step 4: Delete Created Tags
 
 For each ID in `created_resources.tags`:
 ```
@@ -314,7 +367,7 @@ delete_transaction_tag(tag_id = {id})
 ```
 Log success/failure for each. Continue on failure.
 
-### Step 4b: Delete Created Categories
+#### Step 4b: Delete Created Categories
 
 For each ID in `created_resources.categories`:
 ```
@@ -322,7 +375,7 @@ delete_transaction_category(category_id = {id})
 ```
 Log success/failure for each. Continue on failure.
 
-### Step 4c: Delete Created Accounts
+#### Step 4c: Delete Created Accounts
 
 For each ID in `created_resources.accounts`:
 ```
@@ -330,11 +383,11 @@ delete_account(account_id = {id})
 ```
 Log success/failure for each. Continue on failure.
 
-### Step 5: Verify Tag Cleanup
+#### Step 5: Verify Tag Cleanup
 
 Call `get_transaction_tags()`. Confirm none of the returned tags have names starting with `MCP-Test-`. If any remain, attempt to delete them and warn the user.
 
-### Step 6: Finalize
+#### Step 6: Finalize
 
 Set `status: "completed"` in state file, then delete `mcp-test-state.json`.
 
@@ -342,22 +395,53 @@ Set `status: "completed"` in state file, then delete `mcp-test-state.json`.
 
 ## Reporting
 
-After cleanup, print a final summary:
+After cleanup (or after skipping cleanup in read-only mode), print a final summary.
+
+### Read-only mode example:
 
 ```
-╔══════════════════════════════════════════╗
-║       MCP Tool Test Results Summary      ║
-╠══════════════════════════════════════════╣
-║ Phase 1 — Auth Tools:        3/3  PASS   ║
-║ Phase 2 — Accounts:          5/5  PASS   ║
-║ Phase 3 — Transaction Reads: 14/14 PASS  ║
-║ Phase 4 — Budgets/Cashflow:  12/12 PASS  ║
-║ Phase 5 — Tag CRUD:          13/13 PASS  ║
-║ Phase 6 — Transaction CRUD:  25/25 PASS  ║
-║ Phase 7 — Tagging:           5/5  PASS   ║
-╠══════════════════════════════════════════╣
-║ TOTAL: 77 passed, 0 failed, 0 skipped   ║
-╚══════════════════════════════════════════╝
+╔══════════════════════════════════════════════════╗
+║  MCP Tool Test Results Summary (read-only mode)  ║
+╠══════════════════════════════════════════════════╣
+║ Phase 1  — Auth Tools:        3/3  PASS          ║
+║ Phase 2  — Accounts:          5/5  PASS          ║
+║ Phase 3  — Transaction Reads: 14/14 PASS         ║
+║ Phase 4  — Budgets/Cashflow:  12/12 PASS         ║
+║ Phase 5  — Tag CRUD:          1/1  PASS          ║
+║ Phase 6  — Transaction CRUD:  SKIPPED (write)    ║
+║ Phase 7  — Tagging:           SKIPPED (write)    ║
+║ Phase 8  — Categories:        3/3  PASS          ║
+║ Phase 9  — Details/Splits:    5/5  PASS          ║
+║ Phase 10 — Read-Only Tools:   9/9  PASS          ║
+║ Phase 11 — Account Mgmt:      6/6  PASS          ║
+║ Phase 12 — Analytics:         5/5  PASS          ║
+╠══════════════════════════════════════════════════╣
+║ TOTAL: 63 passed, 0 failed, 0 skipped           ║
+║ Write tests skipped: 64 (server in read-only)    ║
+╚══════════════════════════════════════════════════╝
+```
+
+### Write mode example:
+
+```
+╔══════════════════════════════════════════════════╗
+║ MCP Tool Test Results Summary (read-write mode)  ║
+╠══════════════════════════════════════════════════╣
+║ Phase 1  — Auth Tools:        3/3  PASS          ║
+║ Phase 2  — Accounts:          5/5  PASS          ║
+║ Phase 3  — Transaction Reads: 14/14 PASS         ║
+║ Phase 4  — Budgets/Cashflow:  15/15 PASS         ║
+║ Phase 5  — Tag CRUD:          13/13 PASS         ║
+║ Phase 6  — Transaction CRUD:  25/25 PASS         ║
+║ Phase 7  — Tagging:           5/5  PASS          ║
+║ Phase 8  — Categories:        10/10 PASS         ║
+║ Phase 9  — Details/Splits:    8/8  PASS          ║
+║ Phase 10 — Read-Only Tools:   9/9  PASS          ║
+║ Phase 11 — Account Mgmt:      10/10 PASS         ║
+║ Phase 12 — Analytics:         5/5  PASS          ║
+╠══════════════════════════════════════════════════╣
+║ TOTAL: 127 passed, 0 failed, 0 skipped          ║
+╚══════════════════════════════════════════════════╝
 ```
 
 If any tests failed, list each failure with:

--- a/.claude/skills/test-monarch-mcp/references/account-management.md
+++ b/.claude/skills/test-monarch-mcp/references/account-management.md
@@ -1,5 +1,7 @@
 # Phase 11 — Account Management (10 tests)
 
+> **Read-only mode:** Run tests 11.1, 11.6-alt, 11.7-11.10. Skip 11.2-11.6 (create/update/delete account requires write mode).
+
 ## 11.1 — get_account_type_options: returns valid types
 Call `get_account_type_options()`.
 **Expected:** JSON with account type options. Record a valid `account_type` and `account_sub_type` for later use.
@@ -23,6 +25,13 @@ Call `update_account(account_id={created_account_id}, include_in_net_worth=True)
 ## 11.6 — get_account_history: for created account
 Call `get_account_history(account_id={created_account_id})`.
 **Expected:** JSON response (may have limited history for a brand new account).
+
+## 11.6-alt — get_account_history: for checking account (read-only variant)
+
+> **This test replaces 11.6 in read-only mode**, since no account is created.
+
+Call `get_account_history(account_id={checking_account_id})`.
+**Expected:** JSON with historical balance snapshots for a real account.
 
 ## 11.7 — get_recent_account_balances: no date
 Call `get_recent_account_balances()`.

--- a/.claude/skills/test-monarch-mcp/references/budgets-and-cashflow.md
+++ b/.claude/skills/test-monarch-mcp/references/budgets-and-cashflow.md
@@ -1,5 +1,7 @@
 # Phase 4 — Budgets, Cashflow & Budget Amounts (15 tests)
 
+> **Read-only mode:** Run tests 4.1-4.12 only. Skip 4.13-4.15 (set_budget_amount requires write mode).
+
 ---
 
 ## Test 4.1 — get_budgets: Both Dates (Jan 2025)

--- a/.claude/skills/test-monarch-mcp/references/categories.md
+++ b/.claude/skills/test-monarch-mcp/references/categories.md
@@ -1,5 +1,7 @@
 # Phase 8 — Categories (10 tests)
 
+> **Read-only mode:** Run tests 8.1-8.3 only. Skip 8.4-8.10 (create/delete category requires write mode).
+
 ## 8.1 — get_transaction_categories: returns categories
 Call `get_transaction_categories()`.
 **Expected:** JSON with a `categories` key containing a non-empty list. Each category has `id`, `name`, and `group`.

--- a/.claude/skills/test-monarch-mcp/references/tag-crud.md
+++ b/.claude/skills/test-monarch-mcp/references/tag-crud.md
@@ -1,5 +1,7 @@
 # Phase 5 — Tag CRUD (13 tests)
 
+> **Read-only mode:** Run test 5.1 only. Skip 5.2-5.13 (create/delete tag requires write mode).
+
 **Important:** After every successful `create_transaction_tag` call, immediately append the returned tag ID to `created_resources.tags` in the state file before running the next test.
 
 ---

--- a/.claude/skills/test-monarch-mcp/references/transaction-details-and-splits.md
+++ b/.claude/skills/test-monarch-mcp/references/transaction-details-and-splits.md
@@ -1,5 +1,7 @@
 # Phase 9 — Transaction Details & Splits (8 tests)
 
+> **Read-only mode:** Run tests 9.1-9.5 only. Skip 9.6-9.8 (update_transaction_splits and create_transaction require write mode).
+
 ## 9.1 — get_transaction_details: happy path
 Call `get_transaction_details(transaction_id={test_transaction_id})`.
 **Expected:** JSON with detailed transaction info including `id`, `date`, `amount`, `merchant`, `category`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,13 @@
 # CLAUDE.md — Monarch MCP Server
 
+## Branching Policy
+
+**Never commit directly to `main`** unless the user explicitly asks for it.
+
+- If on `main`, create a new feature branch before committing (e.g., `feature/<topic>`), or switch to an existing branch.
+- If unsure which branch to use, ask the user.
+- This applies to all commits — fixes, features, refactors, docs, etc.
+
 ## Documentation Maintenance
 
 Keep `README.md` up to date whenever:

--- a/README.md
+++ b/README.md
@@ -92,6 +92,45 @@ Once authenticated, use these tools directly in Claude Desktop:
 - `get_budgets` - Budget information and spending
 - `get_cashflow` - Income/expense analysis
 
+### Read-Only Mode (Default)
+
+The server starts in **read-only mode** by default — only query tools are available. The 13 write tools (create, update, delete) are hidden and blocked until you explicitly opt in.
+
+**Enable write tools via CLI:**
+```bash
+# Bare flag
+monarch-mcp-server --enable-write
+
+# Explicit value
+monarch-mcp-server --enable-write=true
+```
+
+**Enable write tools in Claude Desktop (`.mcpb` install):**
+
+The `.mcpb` bundle includes a toggle in Claude Desktop's server settings. Open the Monarch Money server configuration and enable **"Enable write tools"**.
+
+**Enable write tools in manual Claude Desktop config:**
+
+Add `--enable-write` to the `args` array:
+
+```json
+{
+  "mcpServers": {
+    "Monarch Money": {
+      "command": "python3",
+      "args": ["-m", "monarch_mcp_server", "--enable-write"]
+    }
+  }
+}
+```
+
+**Write tools controlled by this flag:**
+`create_transaction`, `update_transaction`, `delete_transaction`,
+`create_transaction_tag`, `delete_transaction_tag`, `set_transaction_tags`,
+`set_budget_amount`, `update_transaction_splits`,
+`create_transaction_category`, `delete_transaction_category`,
+`create_manual_account`, `update_account`, `delete_account`
+
 ## ✨ Features
 
 ### 📊 Account Management

--- a/manifest.json
+++ b/manifest.json
@@ -17,7 +17,7 @@
         "run",
         "--directory",
         "${__dirname}",
-        "mcp",
+        "fastmcp",
         "run",
         "${__dirname}/src/monarch_mcp_server/server.py"
       ]

--- a/manifest.json
+++ b/manifest.json
@@ -19,8 +19,18 @@
         "${__dirname}",
         "fastmcp",
         "run",
-        "${__dirname}/src/monarch_mcp_server/server.py"
+        "${__dirname}/src/monarch_mcp_server/server.py",
+        "--",
+        "--enable-write=${user_config.enable_write}"
       ]
+    }
+  },
+  "user_config": {
+    "enable_write": {
+      "type": "boolean",
+      "title": "Enable write tools",
+      "description": "Allow creating, updating, and deleting data. Read-only by default.",
+      "default": false
     }
   },
   "tools": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "fastmcp>=2.0.0",
+    "fastmcp>=2.8.0",
     "monarchmoneycommunity~=1.3.0",
     "keyring>=24.0.0",
     "python-dotenv>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "mcp[cli]>=1.0.0",
+    "fastmcp>=2.0.0",
     "monarchmoneycommunity~=1.3.0",
     "keyring>=24.0.0",
     "python-dotenv>=1.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "fastmcp>=2.8.0",
+    "fastmcp>=2.12.0",
     "monarchmoneycommunity~=1.3.0",
     "keyring>=24.0.0",
     "python-dotenv>=1.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mcp[cli]>=1.0.0
+fastmcp>=2.0.0
 monarchmoneycommunity~=1.3.0
 keyring>=24.0.0
 python-dotenv>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastmcp>=2.0.0
+fastmcp>=2.8.0
 monarchmoneycommunity~=1.3.0
 keyring>=24.0.0
 python-dotenv>=1.0.0

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -30,7 +30,8 @@ load_dotenv()
 
 # ── Read-only mode (write tools disabled by default) ─────────────────
 _arg_parser = argparse.ArgumentParser(
-    description="Monarch Money MCP Server",
+    description="Monarch Money MCP Server — read-only by default; "
+                "pass --enable-write to expose write tools.",
 )
 _arg_parser.add_argument(
     "--enable-write",

--- a/src/monarch_mcp_server/server.py
+++ b/src/monarch_mcp_server/server.py
@@ -12,7 +12,7 @@ from typing import Any, Dict, List, Optional
 from concurrent.futures import ThreadPoolExecutor
 
 from dotenv import load_dotenv
-from mcp.server.fastmcp import FastMCP
+from fastmcp import FastMCP
 from gql import gql
 from gql.transport.exceptions import TransportServerError, TransportQueryError, TransportError
 from monarchmoney import MonarchMoney, LoginFailedException

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,17 @@ Two-tier mocking convention:
 from unittest.mock import patch, AsyncMock  # pylint: disable=unused-import
 
 import pytest
+from fastmcp.tools.tool import FunctionTool
+
+import monarch_mcp_server.server as _server_module
+
+# fastmcp >= 2.8 wraps @mcp.tool() functions in FunctionTool objects that are
+# not directly callable.  Unwrap them so existing tests can call the functions
+# (e.g. ``get_accounts()``) without changes.
+for _attr_name in list(dir(_server_module)):
+    _attr = getattr(_server_module, _attr_name)
+    if isinstance(_attr, FunctionTool):
+        setattr(_server_module, _attr_name, _attr.fn)
 
 
 @pytest.fixture

--- a/tests/test_account_management.py
+++ b/tests/test_account_management.py
@@ -24,7 +24,7 @@ async def test_create_account_happy(mcp_write_client, mock_monarch_client):
                 "is_in_net_worth": True,
                 "account_balance": 1000.0,
             },
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["createManualAccount"]["id"] == "acc-new"
@@ -69,7 +69,7 @@ async def test_create_account_error(mcp_write_client, mock_monarch_client):
             "account_sub_type": "bad",
             "is_in_net_worth": True,
         },
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
 
@@ -88,7 +88,7 @@ async def test_update_account_name(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "update_account", {"account_id": "acc-1", "account_name": "New Name"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["displayName"] == "New Name"
@@ -106,7 +106,7 @@ async def test_update_account_balance(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "update_account", {"account_id": "acc-1", "account_balance": 5000.0}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["currentBalance"] == 5000.0
@@ -118,7 +118,7 @@ async def test_update_account_noop(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "update_account", {"account_id": "acc-1"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["id"] == "acc-1"
@@ -150,7 +150,7 @@ async def test_update_account_error(mcp_write_client, mock_monarch_client):
 
     result = (await mcp_write_client.call_tool(
         "update_account", {"account_id": "bad-id", "account_name": "X"}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
 
@@ -166,7 +166,7 @@ async def test_delete_account_happy(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "delete_account", {"account_id": "acc-1"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["deleted"] is True
@@ -180,7 +180,7 @@ async def test_delete_account_error(mcp_write_client, mock_monarch_client):
 
     result = (await mcp_write_client.call_tool(
         "delete_account", {"account_id": "bad-id"}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
 
@@ -201,7 +201,7 @@ async def test_account_history_happy(mcp_client, mock_monarch_client):
     result = json.loads(
         (await mcp_client.call_tool(
             "get_account_history", {"account_id": "acc-1"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert len(result["accountHistory"]) == 2
@@ -213,7 +213,7 @@ async def test_account_history_error(mcp_client, mock_monarch_client):
 
     result = (await mcp_client.call_tool(
         "get_account_history", {"account_id": "bad-id"}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
 
@@ -287,7 +287,7 @@ async def test_snapshots_by_type_invalid_timeframe(mcp_client):
         (await mcp_client.call_tool(
             "get_account_snapshots_by_type",
             {"start_date": "2025-01-01", "timeframe": "week"},
-        ))[0].text
+        )).content[0].text
     )
     assert "error" in result
 
@@ -344,7 +344,7 @@ async def test_account_type_options_happy(mcp_client, mock_monarch_client):
     }
 
     result = json.loads(
-        (await mcp_client.call_tool("get_account_type_options"))[0].text
+        (await mcp_client.call_tool("get_account_type_options")).content[0].text
     )
 
     assert len(result["accountTypeOptions"]) == 1
@@ -362,7 +362,7 @@ async def test_credit_history_happy(mcp_client, mock_monarch_client):
     }
 
     result = json.loads(
-        (await mcp_client.call_tool("get_credit_history"))[0].text
+        (await mcp_client.call_tool("get_credit_history")).content[0].text
     )
 
     assert result["creditHistory"][0]["score"] == 750
@@ -373,7 +373,7 @@ async def test_credit_history_empty(mcp_client, mock_monarch_client):
     mock_monarch_client.get_credit_history.return_value = {"creditHistory": []}
 
     result = json.loads(
-        (await mcp_client.call_tool("get_credit_history"))[0].text
+        (await mcp_client.call_tool("get_credit_history")).content[0].text
     )
 
     assert result["creditHistory"] == []

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -34,7 +34,7 @@ SAMPLE_HOLDING = {
 async def test_get_accounts_happy_path(mcp_client, mock_monarch_client):
     mock_monarch_client.get_accounts.return_value = {"accounts": [SAMPLE_ACCOUNT]}
 
-    result = json.loads((await mcp_client.call_tool("get_accounts"))[0].text)
+    result = json.loads((await mcp_client.call_tool("get_accounts")).content[0].text)
 
     assert len(result) == 1
     acct = result[0]
@@ -52,7 +52,7 @@ async def test_get_account_holdings_investment(mcp_client, mock_monarch_client):
     }
 
     result = json.loads(
-        (await mcp_client.call_tool("get_account_holdings", {"account_id": "acc-inv"}))[0].text
+        (await mcp_client.call_tool("get_account_holdings", {"account_id": "acc-inv"})).content[0].text
     )
 
     assert result["holdings"][0]["ticker"] == "VTI"
@@ -63,7 +63,7 @@ async def test_get_account_holdings_non_investment(mcp_client, mock_monarch_clie
     mock_monarch_client.get_account_holdings.return_value = {"holdings": []}
 
     result = json.loads(
-        (await mcp_client.call_tool("get_account_holdings", {"account_id": "acc-checking"}))[0].text
+        (await mcp_client.call_tool("get_account_holdings", {"account_id": "acc-checking"})).content[0].text
     )
 
     assert result["holdings"] == []
@@ -74,7 +74,7 @@ async def test_get_account_holdings_invalid_id(mcp_client, mock_monarch_client):
         "Account not found"
     )
 
-    result = (await mcp_client.call_tool("get_account_holdings", {"account_id": "bad-id"}))[0].text
+    result = (await mcp_client.call_tool("get_account_holdings", {"account_id": "bad-id"})).content[0].text
 
     assert "Error" in result
     assert "Account not found" in result
@@ -86,7 +86,7 @@ async def test_refresh_accounts(mcp_client, mock_monarch_client):
     }
     mock_monarch_client.request_accounts_refresh.return_value = {"success": True}
 
-    result = json.loads((await mcp_client.call_tool("refresh_accounts"))[0].text)
+    result = json.loads((await mcp_client.call_tool("refresh_accounts")).content[0].text)
 
     assert result["success"] is True
     mock_monarch_client.get_accounts.assert_called_once()

--- a/tests/test_accounts.py
+++ b/tests/test_accounts.py
@@ -3,11 +3,6 @@
 
 import json
 
-from monarch_mcp_server.server import (
-    get_accounts,
-    get_account_holdings,
-    refresh_accounts,
-)
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -36,10 +31,10 @@ SAMPLE_HOLDING = {
 # ---------------------------------------------------------------------------
 
 
-def test_get_accounts_happy_path(mock_monarch_client):
+async def test_get_accounts_happy_path(mcp_client, mock_monarch_client):
     mock_monarch_client.get_accounts.return_value = {"accounts": [SAMPLE_ACCOUNT]}
 
-    result = json.loads(get_accounts())
+    result = json.loads((await mcp_client.call_tool("get_accounts"))[0].text)
 
     assert len(result) == 1
     acct = result[0]
@@ -51,43 +46,47 @@ def test_get_accounts_happy_path(mock_monarch_client):
     assert acct["is_active"] is True
 
 
-def test_get_account_holdings_investment(mock_monarch_client):
+async def test_get_account_holdings_investment(mcp_client, mock_monarch_client):
     mock_monarch_client.get_account_holdings.return_value = {
         "holdings": [SAMPLE_HOLDING]
     }
 
-    result = json.loads(get_account_holdings(account_id="acc-inv"))
+    result = json.loads(
+        (await mcp_client.call_tool("get_account_holdings", {"account_id": "acc-inv"}))[0].text
+    )
 
     assert result["holdings"][0]["ticker"] == "VTI"
     mock_monarch_client.get_account_holdings.assert_called_once_with("acc-inv")
 
 
-def test_get_account_holdings_non_investment(mock_monarch_client):
+async def test_get_account_holdings_non_investment(mcp_client, mock_monarch_client):
     mock_monarch_client.get_account_holdings.return_value = {"holdings": []}
 
-    result = json.loads(get_account_holdings(account_id="acc-checking"))
+    result = json.loads(
+        (await mcp_client.call_tool("get_account_holdings", {"account_id": "acc-checking"}))[0].text
+    )
 
     assert result["holdings"] == []
 
 
-def test_get_account_holdings_invalid_id(mock_monarch_client):
+async def test_get_account_holdings_invalid_id(mcp_client, mock_monarch_client):
     mock_monarch_client.get_account_holdings.side_effect = Exception(
         "Account not found"
     )
 
-    result = get_account_holdings(account_id="bad-id")
+    result = (await mcp_client.call_tool("get_account_holdings", {"account_id": "bad-id"}))[0].text
 
     assert "Error" in result
     assert "Account not found" in result
 
 
-def test_refresh_accounts(mock_monarch_client):
+async def test_refresh_accounts(mcp_client, mock_monarch_client):
     mock_monarch_client.get_accounts.return_value = {
         "accounts": [{"id": "acc-1"}, {"id": "acc-2"}]
     }
     mock_monarch_client.request_accounts_refresh.return_value = {"success": True}
 
-    result = json.loads(refresh_accounts())
+    result = json.loads((await mcp_client.call_tool("refresh_accounts"))[0].text)
 
     assert result["success"] is True
     mock_monarch_client.get_accounts.assert_called_once()

--- a/tests/test_auth_tools.py
+++ b/tests/test_auth_tools.py
@@ -3,18 +3,18 @@
 
 
 async def test_check_auth_status_with_token(mcp_client):
-    result = (await mcp_client.call_tool("check_auth_status"))[0].text
+    result = (await mcp_client.call_tool("check_auth_status")).content[0].text
     assert "Authentication token found" in result
 
 
 async def test_debug_session_loading_with_token(mcp_client):
-    result = (await mcp_client.call_tool("debug_session_loading"))[0].text
+    result = (await mcp_client.call_tool("debug_session_loading")).content[0].text
     assert "Token found in keyring" in result
     assert "length:" in result
 
 
 async def test_setup_authentication(mcp_client):
-    result = (await mcp_client.call_tool("setup_authentication"))[0].text
+    result = (await mcp_client.call_tool("setup_authentication")).content[0].text
     assert "Authentication" in result
     assert "\n" in result  # multi-line instructions
     assert "get_accounts" in result

--- a/tests/test_auth_tools.py
+++ b/tests/test_auth_tools.py
@@ -1,26 +1,20 @@
 """Phase 1: Authentication tool tests (3 tests)."""
 # pylint: disable=missing-function-docstring
 
-from monarch_mcp_server.server import (
-    check_auth_status,
-    debug_session_loading,
-    setup_authentication,
-)
 
-
-def test_check_auth_status_with_token():
-    result = check_auth_status()
+async def test_check_auth_status_with_token(mcp_client):
+    result = (await mcp_client.call_tool("check_auth_status"))[0].text
     assert "Authentication token found" in result
 
 
-def test_debug_session_loading_with_token():
-    result = debug_session_loading()
+async def test_debug_session_loading_with_token(mcp_client):
+    result = (await mcp_client.call_tool("debug_session_loading"))[0].text
     assert "Token found in keyring" in result
     assert "length:" in result
 
 
-def test_setup_authentication():
-    result = setup_authentication()
+async def test_setup_authentication(mcp_client):
+    result = (await mcp_client.call_tool("setup_authentication"))[0].text
     assert "Authentication" in result
     assert "\n" in result  # multi-line instructions
     assert "get_accounts" in result

--- a/tests/test_budget_set.py
+++ b/tests/test_budget_set.py
@@ -12,7 +12,7 @@ async def test_set_budget_with_category(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "set_budget_amount", {"amount": 500.0, "category_id": "cat-1"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert "updateOrCreateBudgetItem" in result
@@ -32,7 +32,7 @@ async def test_set_budget_with_group(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "set_budget_amount", {"amount": 2000.0, "category_group_id": "grp-1"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert "updateOrCreateBudgetItem" in result
@@ -49,7 +49,7 @@ async def test_set_budget_both_ids_error(mcp_write_client):
         (await mcp_write_client.call_tool(
             "set_budget_amount",
             {"amount": 100.0, "category_id": "cat-1", "category_group_id": "grp-1"},
-        ))[0].text
+        )).content[0].text
     )
     assert "error" in result
     assert "exactly one" in result["error"].lower()
@@ -59,7 +59,7 @@ async def test_set_budget_neither_id_error(mcp_write_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "set_budget_amount", {"amount": 100.0}
-        ))[0].text
+        )).content[0].text
     )
     assert "error" in result
     assert "exactly one" in result["error"].lower()
@@ -98,6 +98,6 @@ async def test_set_budget_error(mcp_write_client, mock_monarch_client):
 
     result = (await mcp_write_client.call_tool(
         "set_budget_amount", {"amount": 100.0, "category_id": "bad-cat"}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result

--- a/tests/test_budget_set.py
+++ b/tests/test_budget_set.py
@@ -3,15 +3,17 @@
 
 import json
 
-from monarch_mcp_server.server import set_budget_amount
 
-
-def test_set_budget_with_category(mock_monarch_client):
+async def test_set_budget_with_category(mcp_write_client, mock_monarch_client):
     mock_monarch_client.set_budget_amount.return_value = {
         "updateOrCreateBudgetItem": {"id": "budget-1"}
     }
 
-    result = json.loads(set_budget_amount(amount=500.0, category_id="cat-1"))
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "set_budget_amount", {"amount": 500.0, "category_id": "cat-1"}
+        ))[0].text
+    )
 
     assert "updateOrCreateBudgetItem" in result
     mock_monarch_client.set_budget_amount.assert_called_once_with(
@@ -22,12 +24,16 @@ def test_set_budget_with_category(mock_monarch_client):
     )
 
 
-def test_set_budget_with_group(mock_monarch_client):
+async def test_set_budget_with_group(mcp_write_client, mock_monarch_client):
     mock_monarch_client.set_budget_amount.return_value = {
         "updateOrCreateBudgetItem": {"id": "budget-2"}
     }
 
-    result = json.loads(set_budget_amount(amount=2000.0, category_group_id="grp-1"))
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "set_budget_amount", {"amount": 2000.0, "category_group_id": "grp-1"}
+        ))[0].text
+    )
 
     assert "updateOrCreateBudgetItem" in result
     mock_monarch_client.set_budget_amount.assert_called_once_with(
@@ -38,47 +44,60 @@ def test_set_budget_with_group(mock_monarch_client):
     )
 
 
-def test_set_budget_both_ids_error():
+async def test_set_budget_both_ids_error(mcp_write_client):
     result = json.loads(
-        set_budget_amount(amount=100.0, category_id="cat-1", category_group_id="grp-1")
+        (await mcp_write_client.call_tool(
+            "set_budget_amount",
+            {"amount": 100.0, "category_id": "cat-1", "category_group_id": "grp-1"},
+        ))[0].text
     )
     assert "error" in result
     assert "exactly one" in result["error"].lower()
 
 
-def test_set_budget_neither_id_error():
-    result = json.loads(set_budget_amount(amount=100.0))
+async def test_set_budget_neither_id_error(mcp_write_client):
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "set_budget_amount", {"amount": 100.0}
+        ))[0].text
+    )
     assert "error" in result
     assert "exactly one" in result["error"].lower()
 
 
-def test_set_budget_apply_to_future(mock_monarch_client):
+async def test_set_budget_apply_to_future(mcp_write_client, mock_monarch_client):
     mock_monarch_client.set_budget_amount.return_value = {
         "updateOrCreateBudgetItem": {"id": "budget-1"}
     }
 
-    set_budget_amount(amount=300.0, category_id="cat-1", apply_to_future=True)
+    await mcp_write_client.call_tool(
+        "set_budget_amount",
+        {"amount": 300.0, "category_id": "cat-1", "apply_to_future": True},
+    )
 
     call_kwargs = mock_monarch_client.set_budget_amount.call_args[1]
     assert call_kwargs["apply_to_future"] is True
 
 
-def test_set_budget_with_start_date(mock_monarch_client):
+async def test_set_budget_with_start_date(mcp_write_client, mock_monarch_client):
     mock_monarch_client.set_budget_amount.return_value = {
         "updateOrCreateBudgetItem": {"id": "budget-1"}
     }
 
-    set_budget_amount(
-        amount=400.0, category_id="cat-1", start_date="2025-02-01"
+    await mcp_write_client.call_tool(
+        "set_budget_amount",
+        {"amount": 400.0, "category_id": "cat-1", "start_date": "2025-02-01"},
     )
 
     call_kwargs = mock_monarch_client.set_budget_amount.call_args[1]
     assert call_kwargs["start_date"] == "2025-02-01"
 
 
-def test_set_budget_error(mock_monarch_client):
+async def test_set_budget_error(mcp_write_client, mock_monarch_client):
     mock_monarch_client.set_budget_amount.side_effect = Exception("Invalid category")
 
-    result = set_budget_amount(amount=100.0, category_id="bad-cat")
+    result = (await mcp_write_client.call_tool(
+        "set_budget_amount", {"amount": 100.0, "category_id": "bad-cat"}
+    ))[0].text
 
     assert "Error" in result

--- a/tests/test_budgets_cashflow.py
+++ b/tests/test_budgets_cashflow.py
@@ -27,7 +27,7 @@ async def test_budgets_both_dates(mcp_client, mock_monarch_client):
     result = json.loads(
         (await mcp_client.call_tool(
             "get_budgets", {"start_date": "2025-01-01", "end_date": "2025-01-31"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert "budgetData" in result
@@ -39,7 +39,7 @@ async def test_budgets_both_dates(mcp_client, mock_monarch_client):
 async def test_budgets_no_dates(mcp_client, mock_monarch_client):
     mock_monarch_client.get_budgets.return_value = SAMPLE_BUDGET
 
-    result = json.loads((await mcp_client.call_tool("get_budgets"))[0].text)
+    result = json.loads((await mcp_client.call_tool("get_budgets")).content[0].text)
 
     assert "budgetData" in result
     mock_monarch_client.get_budgets.assert_called_once_with(use_v2_goals=True)
@@ -47,14 +47,14 @@ async def test_budgets_no_dates(mcp_client, mock_monarch_client):
 
 async def test_budgets_only_start(mcp_client):
     result = json.loads(
-        (await mcp_client.call_tool("get_budgets", {"start_date": "2025-01-01"}))[0].text
+        (await mcp_client.call_tool("get_budgets", {"start_date": "2025-01-01"})).content[0].text
     )
     assert "error" in result
 
 
 async def test_budgets_only_end(mcp_client):
     result = json.loads(
-        (await mcp_client.call_tool("get_budgets", {"end_date": "2025-01-31"}))[0].text
+        (await mcp_client.call_tool("get_budgets", {"end_date": "2025-01-31"})).content[0].text
     )
     assert "error" in result
 
@@ -64,7 +64,7 @@ async def test_budgets_invalid_format(mcp_client, mock_monarch_client):
 
     result = (await mcp_client.call_tool(
         "get_budgets", {"start_date": "bad", "end_date": "bad"}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
     assert "Invalid date" in result
@@ -76,7 +76,7 @@ async def test_budgets_future_dates(mcp_client, mock_monarch_client):
     result = json.loads(
         (await mcp_client.call_tool(
             "get_budgets", {"start_date": "2099-01-01", "end_date": "2099-12-31"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["budgetData"] is None
@@ -109,7 +109,7 @@ async def test_cashflow_both_dates(mcp_client, mock_monarch_client):
     result = json.loads(
         (await mcp_client.call_tool(
             "get_cashflow", {"start_date": "2025-01-01", "end_date": "2025-01-31"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert "summary" in result
@@ -121,7 +121,7 @@ async def test_cashflow_both_dates(mcp_client, mock_monarch_client):
 async def test_cashflow_no_dates(mcp_client, mock_monarch_client):
     mock_monarch_client.get_cashflow.return_value = SAMPLE_CASHFLOW
 
-    result = json.loads((await mcp_client.call_tool("get_cashflow"))[0].text)
+    result = json.loads((await mcp_client.call_tool("get_cashflow")).content[0].text)
 
     assert "summary" in result
     mock_monarch_client.get_cashflow.assert_called_once_with()
@@ -129,14 +129,14 @@ async def test_cashflow_no_dates(mcp_client, mock_monarch_client):
 
 async def test_cashflow_only_start(mcp_client):
     result = json.loads(
-        (await mcp_client.call_tool("get_cashflow", {"start_date": "2025-01-01"}))[0].text
+        (await mcp_client.call_tool("get_cashflow", {"start_date": "2025-01-01"})).content[0].text
     )
     assert "error" in result
 
 
 async def test_cashflow_only_end(mcp_client):
     result = json.loads(
-        (await mcp_client.call_tool("get_cashflow", {"end_date": "2025-01-31"}))[0].text
+        (await mcp_client.call_tool("get_cashflow", {"end_date": "2025-01-31"})).content[0].text
     )
     assert "error" in result
 
@@ -146,7 +146,7 @@ async def test_cashflow_invalid_format(mcp_client, mock_monarch_client):
 
     result = (await mcp_client.call_tool(
         "get_cashflow", {"start_date": "bad", "end_date": "bad"}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
     assert "Invalid date" in result
@@ -158,7 +158,7 @@ async def test_cashflow_future_dates(mcp_client, mock_monarch_client):
     result = json.loads(
         (await mcp_client.call_tool(
             "get_cashflow", {"start_date": "2099-01-01", "end_date": "2099-12-31"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["summary"] == []

--- a/tests/test_budgets_cashflow.py
+++ b/tests/test_budgets_cashflow.py
@@ -3,7 +3,6 @@
 
 import json
 
-from monarch_mcp_server.server import get_budgets, get_cashflow
 
 SAMPLE_BUDGET = {
     "budgetData": {
@@ -22,10 +21,14 @@ SAMPLE_CASHFLOW = {
 # ===================================================================
 
 
-def test_budgets_both_dates(mock_monarch_client):
+async def test_budgets_both_dates(mcp_client, mock_monarch_client):
     mock_monarch_client.get_budgets.return_value = SAMPLE_BUDGET
 
-    result = json.loads(get_budgets(start_date="2025-01-01", end_date="2025-01-31"))
+    result = json.loads(
+        (await mcp_client.call_tool(
+            "get_budgets", {"start_date": "2025-01-01", "end_date": "2025-01-31"}
+        ))[0].text
+    )
 
     assert "budgetData" in result
     mock_monarch_client.get_budgets.assert_called_once_with(
@@ -33,56 +36,64 @@ def test_budgets_both_dates(mock_monarch_client):
     )
 
 
-def test_budgets_no_dates(mock_monarch_client):
+async def test_budgets_no_dates(mcp_client, mock_monarch_client):
     mock_monarch_client.get_budgets.return_value = SAMPLE_BUDGET
 
-    result = json.loads(get_budgets())
+    result = json.loads((await mcp_client.call_tool("get_budgets"))[0].text)
 
     assert "budgetData" in result
     mock_monarch_client.get_budgets.assert_called_once_with(use_v2_goals=True)
 
 
-def test_budgets_only_start():
-    result = json.loads(get_budgets(start_date="2025-01-01"))
+async def test_budgets_only_start(mcp_client):
+    result = json.loads(
+        (await mcp_client.call_tool("get_budgets", {"start_date": "2025-01-01"}))[0].text
+    )
     assert "error" in result
 
 
-def test_budgets_only_end():
-    result = json.loads(get_budgets(end_date="2025-01-31"))
+async def test_budgets_only_end(mcp_client):
+    result = json.loads(
+        (await mcp_client.call_tool("get_budgets", {"end_date": "2025-01-31"}))[0].text
+    )
     assert "error" in result
 
 
-def test_budgets_invalid_format(mock_monarch_client):
+async def test_budgets_invalid_format(mcp_client, mock_monarch_client):
     mock_monarch_client.get_budgets.side_effect = Exception("Invalid date")
 
-    result = get_budgets(start_date="bad", end_date="bad")
+    result = (await mcp_client.call_tool(
+        "get_budgets", {"start_date": "bad", "end_date": "bad"}
+    ))[0].text
 
     assert "Error" in result
     assert "Invalid date" in result
 
 
-def test_budgets_future_dates(mock_monarch_client):
+async def test_budgets_future_dates(mcp_client, mock_monarch_client):
     mock_monarch_client.get_budgets.return_value = {"budgetData": None}
 
     result = json.loads(
-        get_budgets(start_date="2099-01-01", end_date="2099-12-31")
+        (await mcp_client.call_tool(
+            "get_budgets", {"start_date": "2099-01-01", "end_date": "2099-12-31"}
+        ))[0].text
     )
 
     assert result["budgetData"] is None
 
 
-def test_budgets_v2_goals_default(mock_monarch_client):
+async def test_budgets_v2_goals_default(mcp_client, mock_monarch_client):
     mock_monarch_client.get_budgets.return_value = SAMPLE_BUDGET
 
-    get_budgets()
+    await mcp_client.call_tool("get_budgets")
 
     mock_monarch_client.get_budgets.assert_called_once_with(use_v2_goals=True)
 
 
-def test_budgets_v2_goals_disabled(mock_monarch_client):
+async def test_budgets_v2_goals_disabled(mcp_client, mock_monarch_client):
     mock_monarch_client.get_budgets.return_value = SAMPLE_BUDGET
 
-    get_budgets(use_v2_goals=False)
+    await mcp_client.call_tool("get_budgets", {"use_v2_goals": False})
 
     mock_monarch_client.get_budgets.assert_called_once_with(use_v2_goals=False)
 
@@ -92,11 +103,13 @@ def test_budgets_v2_goals_disabled(mock_monarch_client):
 # ===================================================================
 
 
-def test_cashflow_both_dates(mock_monarch_client):
+async def test_cashflow_both_dates(mcp_client, mock_monarch_client):
     mock_monarch_client.get_cashflow.return_value = SAMPLE_CASHFLOW
 
     result = json.loads(
-        get_cashflow(start_date="2025-01-01", end_date="2025-01-31")
+        (await mcp_client.call_tool(
+            "get_cashflow", {"start_date": "2025-01-01", "end_date": "2025-01-31"}
+        ))[0].text
     )
 
     assert "summary" in result
@@ -105,39 +118,47 @@ def test_cashflow_both_dates(mock_monarch_client):
     )
 
 
-def test_cashflow_no_dates(mock_monarch_client):
+async def test_cashflow_no_dates(mcp_client, mock_monarch_client):
     mock_monarch_client.get_cashflow.return_value = SAMPLE_CASHFLOW
 
-    result = json.loads(get_cashflow())
+    result = json.loads((await mcp_client.call_tool("get_cashflow"))[0].text)
 
     assert "summary" in result
     mock_monarch_client.get_cashflow.assert_called_once_with()
 
 
-def test_cashflow_only_start():
-    result = json.loads(get_cashflow(start_date="2025-01-01"))
+async def test_cashflow_only_start(mcp_client):
+    result = json.loads(
+        (await mcp_client.call_tool("get_cashflow", {"start_date": "2025-01-01"}))[0].text
+    )
     assert "error" in result
 
 
-def test_cashflow_only_end():
-    result = json.loads(get_cashflow(end_date="2025-01-31"))
+async def test_cashflow_only_end(mcp_client):
+    result = json.loads(
+        (await mcp_client.call_tool("get_cashflow", {"end_date": "2025-01-31"}))[0].text
+    )
     assert "error" in result
 
 
-def test_cashflow_invalid_format(mock_monarch_client):
+async def test_cashflow_invalid_format(mcp_client, mock_monarch_client):
     mock_monarch_client.get_cashflow.side_effect = Exception("Invalid date")
 
-    result = get_cashflow(start_date="bad", end_date="bad")
+    result = (await mcp_client.call_tool(
+        "get_cashflow", {"start_date": "bad", "end_date": "bad"}
+    ))[0].text
 
     assert "Error" in result
     assert "Invalid date" in result
 
 
-def test_cashflow_future_dates(mock_monarch_client):
+async def test_cashflow_future_dates(mcp_client, mock_monarch_client):
     mock_monarch_client.get_cashflow.return_value = {"summary": []}
 
     result = json.loads(
-        get_cashflow(start_date="2099-01-01", end_date="2099-12-31")
+        (await mcp_client.call_tool(
+            "get_cashflow", {"start_date": "2099-01-01", "end_date": "2099-12-31"}
+        ))[0].text
     )
 
     assert result["summary"] == []

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -43,7 +43,7 @@ async def test_get_categories_happy(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transaction_categories.return_value = SAMPLE_CATEGORIES
 
     result = json.loads(
-        (await mcp_client.call_tool("get_transaction_categories"))[0].text
+        (await mcp_client.call_tool("get_transaction_categories")).content[0].text
     )
 
     assert len(result["categories"]) == 2
@@ -55,7 +55,7 @@ async def test_get_categories_empty(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transaction_categories.return_value = {"categories": []}
 
     result = json.loads(
-        (await mcp_client.call_tool("get_transaction_categories"))[0].text
+        (await mcp_client.call_tool("get_transaction_categories")).content[0].text
     )
 
     assert result["categories"] == []
@@ -64,7 +64,7 @@ async def test_get_categories_empty(mcp_client, mock_monarch_client):
 async def test_get_categories_error(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transaction_categories.side_effect = Exception("API down")
 
-    result = (await mcp_client.call_tool("get_transaction_categories"))[0].text
+    result = (await mcp_client.call_tool("get_transaction_categories")).content[0].text
 
     assert "Error" in result
 
@@ -78,7 +78,7 @@ async def test_get_category_groups_happy(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transaction_category_groups.return_value = SAMPLE_GROUPS
 
     result = json.loads(
-        (await mcp_client.call_tool("get_transaction_category_groups"))[0].text
+        (await mcp_client.call_tool("get_transaction_category_groups")).content[0].text
     )
 
     assert len(result["categoryGroups"]) == 2
@@ -91,7 +91,7 @@ async def test_get_category_groups_empty(mcp_client, mock_monarch_client):
     }
 
     result = json.loads(
-        (await mcp_client.call_tool("get_transaction_category_groups"))[0].text
+        (await mcp_client.call_tool("get_transaction_category_groups")).content[0].text
     )
 
     assert result["categoryGroups"] == []
@@ -111,7 +111,7 @@ async def test_create_category_happy(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "create_transaction_category", {"group_id": "grp-1", "name": "Coffee"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["name"] == "Coffee"
@@ -137,7 +137,7 @@ async def test_create_category_with_rollover(mcp_write_client, mock_monarch_clie
                 "rollover_enabled": True,
                 "rollover_start_month": "2025-01-01",
             },
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["name"] == "Rent"
@@ -168,7 +168,7 @@ async def test_create_category_error(mcp_write_client, mock_monarch_client):
 
     result = (await mcp_write_client.call_tool(
         "create_transaction_category", {"group_id": "bad-grp", "name": "Test"}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
 
@@ -184,7 +184,7 @@ async def test_delete_category_happy(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "delete_transaction_category", {"category_id": "cat-1"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["deleted"] is True
@@ -200,6 +200,6 @@ async def test_delete_category_error(mcp_write_client, mock_monarch_client):
 
     result = (await mcp_write_client.call_tool(
         "delete_transaction_category", {"category_id": "bad-cat"}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -4,13 +4,6 @@
 import json
 from datetime import datetime
 
-from monarch_mcp_server.server import (
-    get_transaction_categories,
-    get_transaction_category_groups,
-    create_transaction_category,
-    delete_transaction_category,
-)
-
 
 SAMPLE_CATEGORIES = {
     "categories": [
@@ -46,28 +39,32 @@ SAMPLE_GROUPS = {
 # ===================================================================
 
 
-def test_get_categories_happy(mock_monarch_client):
+async def test_get_categories_happy(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transaction_categories.return_value = SAMPLE_CATEGORIES
 
-    result = json.loads(get_transaction_categories())
+    result = json.loads(
+        (await mcp_client.call_tool("get_transaction_categories"))[0].text
+    )
 
     assert len(result["categories"]) == 2
     assert result["categories"][0]["name"] == "Groceries"
     mock_monarch_client.get_transaction_categories.assert_called_once()
 
 
-def test_get_categories_empty(mock_monarch_client):
+async def test_get_categories_empty(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transaction_categories.return_value = {"categories": []}
 
-    result = json.loads(get_transaction_categories())
+    result = json.loads(
+        (await mcp_client.call_tool("get_transaction_categories"))[0].text
+    )
 
     assert result["categories"] == []
 
 
-def test_get_categories_error(mock_monarch_client):
+async def test_get_categories_error(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transaction_categories.side_effect = Exception("API down")
 
-    result = get_transaction_categories()
+    result = (await mcp_client.call_tool("get_transaction_categories"))[0].text
 
     assert "Error" in result
 
@@ -77,21 +74,25 @@ def test_get_categories_error(mock_monarch_client):
 # ===================================================================
 
 
-def test_get_category_groups_happy(mock_monarch_client):
+async def test_get_category_groups_happy(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transaction_category_groups.return_value = SAMPLE_GROUPS
 
-    result = json.loads(get_transaction_category_groups())
+    result = json.loads(
+        (await mcp_client.call_tool("get_transaction_category_groups"))[0].text
+    )
 
     assert len(result["categoryGroups"]) == 2
     mock_monarch_client.get_transaction_category_groups.assert_called_once()
 
 
-def test_get_category_groups_empty(mock_monarch_client):
+async def test_get_category_groups_empty(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transaction_category_groups.return_value = {
         "categoryGroups": []
     }
 
-    result = json.loads(get_transaction_category_groups())
+    result = json.loads(
+        (await mcp_client.call_tool("get_transaction_category_groups"))[0].text
+    )
 
     assert result["categoryGroups"] == []
 
@@ -101,13 +102,17 @@ def test_get_category_groups_empty(mock_monarch_client):
 # ===================================================================
 
 
-def test_create_category_happy(mock_monarch_client):
+async def test_create_category_happy(mcp_write_client, mock_monarch_client):
     mock_monarch_client.create_transaction_category.return_value = {
         "id": "cat-new",
         "name": "Coffee",
     }
 
-    result = json.loads(create_transaction_category(group_id="grp-1", name="Coffee"))
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "create_transaction_category", {"group_id": "grp-1", "name": "Coffee"}
+        ))[0].text
+    )
 
     assert result["name"] == "Coffee"
     call_kwargs = mock_monarch_client.create_transaction_category.call_args[1]
@@ -117,19 +122,22 @@ def test_create_category_happy(mock_monarch_client):
     assert call_kwargs["rollover_enabled"] is False
 
 
-def test_create_category_with_rollover(mock_monarch_client):
+async def test_create_category_with_rollover(mcp_write_client, mock_monarch_client):
     mock_monarch_client.create_transaction_category.return_value = {
         "id": "cat-new",
         "name": "Rent",
     }
 
     result = json.loads(
-        create_transaction_category(
-            group_id="grp-1",
-            name="Rent",
-            rollover_enabled=True,
-            rollover_start_month="2025-01-01",
-        )
+        (await mcp_write_client.call_tool(
+            "create_transaction_category",
+            {
+                "group_id": "grp-1",
+                "name": "Rent",
+                "rollover_enabled": True,
+                "rollover_start_month": "2025-01-01",
+            },
+        ))[0].text
     )
 
     assert result["name"] == "Rent"
@@ -138,24 +146,29 @@ def test_create_category_with_rollover(mock_monarch_client):
     assert call_kwargs["rollover_start_month"] == datetime(2025, 1, 1)
 
 
-def test_create_category_custom_icon(mock_monarch_client):
+async def test_create_category_custom_icon(mcp_write_client, mock_monarch_client):
     mock_monarch_client.create_transaction_category.return_value = {
         "id": "cat-new",
         "name": "Gaming",
     }
 
-    create_transaction_category(group_id="grp-1", name="Gaming", icon="\U0001F3AE")
+    await mcp_write_client.call_tool(
+        "create_transaction_category",
+        {"group_id": "grp-1", "name": "Gaming", "icon": "\U0001F3AE"},
+    )
 
     call_kwargs = mock_monarch_client.create_transaction_category.call_args[1]
     assert call_kwargs["icon"] == "\U0001F3AE"
 
 
-def test_create_category_error(mock_monarch_client):
+async def test_create_category_error(mcp_write_client, mock_monarch_client):
     mock_monarch_client.create_transaction_category.side_effect = Exception(
         "Group not found"
     )
 
-    result = create_transaction_category(group_id="bad-grp", name="Test")
+    result = (await mcp_write_client.call_tool(
+        "create_transaction_category", {"group_id": "bad-grp", "name": "Test"}
+    ))[0].text
 
     assert "Error" in result
 
@@ -165,10 +178,14 @@ def test_create_category_error(mock_monarch_client):
 # ===================================================================
 
 
-def test_delete_category_happy(mock_monarch_client):
+async def test_delete_category_happy(mcp_write_client, mock_monarch_client):
     mock_monarch_client.delete_transaction_category.return_value = True
 
-    result = json.loads(delete_transaction_category(category_id="cat-1"))
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "delete_transaction_category", {"category_id": "cat-1"}
+        ))[0].text
+    )
 
     assert result["deleted"] is True
     assert result["category_id"] == "cat-1"
@@ -176,11 +193,13 @@ def test_delete_category_happy(mock_monarch_client):
     mock_monarch_client.delete_transaction_category.assert_called_once_with("cat-1")
 
 
-def test_delete_category_error(mock_monarch_client):
+async def test_delete_category_error(mcp_write_client, mock_monarch_client):
     mock_monarch_client.delete_transaction_category.side_effect = Exception(
         "Category not found"
     )
 
-    result = delete_transaction_category(category_id="bad-cat")
+    result = (await mcp_write_client.call_tool(
+        "delete_transaction_category", {"category_id": "bad-cat"}
+    ))[0].text
 
     assert "Error" in result

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -105,7 +105,7 @@ async def test_tool_runtime_error(mcp_client, mock_monarch_client):
     """RuntimeError (e.g., auth recovery) returns error string."""
     mock_monarch_client.get_accounts.side_effect = RuntimeError("session expired")
 
-    result = (await mcp_client.call_tool("get_accounts"))[0].text
+    result = (await mcp_client.call_tool("get_accounts")).content[0].text
 
     assert "Error" in result
     assert "session expired" in result
@@ -117,7 +117,7 @@ async def test_tool_transport_server_error(mcp_client, mock_monarch_client):
         "Internal Server Error", code=500,
     )
 
-    result = (await mcp_client.call_tool("get_accounts"))[0].text
+    result = (await mcp_client.call_tool("get_accounts")).content[0].text
 
     assert "Error" in result
     assert "500" in result
@@ -129,7 +129,7 @@ async def test_tool_transport_query_error(mcp_client, mock_monarch_client):
         "Validation error",
     )
 
-    result = (await mcp_client.call_tool("get_accounts"))[0].text
+    result = (await mcp_client.call_tool("get_accounts")).content[0].text
 
     assert "Error" in result
     assert "query" in result.lower()
@@ -141,7 +141,7 @@ async def test_tool_transport_error(mcp_client, mock_monarch_client):
         "Connection refused",
     )
 
-    result = (await mcp_client.call_tool("get_accounts"))[0].text
+    result = (await mcp_client.call_tool("get_accounts")).content[0].text
 
     assert "Error" in result
     assert "connection" in result.lower()
@@ -151,7 +151,7 @@ async def test_tool_unexpected_error(mcp_client, mock_monarch_client):
     """Generic Exception returns catch-all error."""
     mock_monarch_client.get_accounts.side_effect = ValueError("weird error")
 
-    result = (await mcp_client.call_tool("get_accounts"))[0].text
+    result = (await mcp_client.call_tool("get_accounts")).content[0].text
 
     assert "Error" in result
     assert "weird error" in result

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -7,7 +7,7 @@ import pytest
 from gql.transport.exceptions import TransportServerError, TransportQueryError, TransportError
 from monarchmoney import LoginFailedException
 
-from monarch_mcp_server.server import run_async, get_accounts
+from monarch_mcp_server.server import run_async
 from monarch_mcp_server.auth_server import _AuthHandler, _AuthState
 
 
@@ -97,61 +97,61 @@ def test_run_async_transport_query_error_propagates():
 
 
 # ===================================================================
-# MCP tool decorator — exception type discrimination
+# MCP tool decorator — exception type discrimination (via Client)
 # ===================================================================
 
 
-def test_tool_runtime_error(mock_monarch_client):
+async def test_tool_runtime_error(mcp_client, mock_monarch_client):
     """RuntimeError (e.g., auth recovery) returns error string."""
     mock_monarch_client.get_accounts.side_effect = RuntimeError("session expired")
 
-    result = get_accounts()
+    result = (await mcp_client.call_tool("get_accounts"))[0].text
 
     assert "Error" in result
     assert "session expired" in result
 
 
-def test_tool_transport_server_error(mock_monarch_client):
+async def test_tool_transport_server_error(mcp_client, mock_monarch_client):
     """TransportServerError includes HTTP status code in error."""
     mock_monarch_client.get_accounts.side_effect = TransportServerError(
         "Internal Server Error", code=500,
     )
 
-    result = get_accounts()
+    result = (await mcp_client.call_tool("get_accounts"))[0].text
 
     assert "Error" in result
     assert "500" in result
 
 
-def test_tool_transport_query_error(mock_monarch_client):
+async def test_tool_transport_query_error(mcp_client, mock_monarch_client):
     """TransportQueryError returns query-specific error."""
     mock_monarch_client.get_accounts.side_effect = TransportQueryError(
         "Validation error",
     )
 
-    result = get_accounts()
+    result = (await mcp_client.call_tool("get_accounts"))[0].text
 
     assert "Error" in result
     assert "query" in result.lower()
 
 
-def test_tool_transport_error(mock_monarch_client):
+async def test_tool_transport_error(mcp_client, mock_monarch_client):
     """TransportError returns connection-specific error."""
     mock_monarch_client.get_accounts.side_effect = TransportError(
         "Connection refused",
     )
 
-    result = get_accounts()
+    result = (await mcp_client.call_tool("get_accounts"))[0].text
 
     assert "Error" in result
     assert "connection" in result.lower()
 
 
-def test_tool_unexpected_error(mock_monarch_client):
+async def test_tool_unexpected_error(mcp_client, mock_monarch_client):
     """Generic Exception returns catch-all error."""
     mock_monarch_client.get_accounts.side_effect = ValueError("weird error")
 
-    result = get_accounts()
+    result = (await mcp_client.call_tool("get_accounts"))[0].text
 
     assert "Error" in result
     assert "weird error" in result

--- a/tests/test_read_tools.py
+++ b/tests/test_read_tools.py
@@ -29,7 +29,7 @@ SAMPLE_SUMMARY = {
 async def test_summary_happy(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions_summary.return_value = SAMPLE_SUMMARY
 
-    result = json.loads((await mcp_client.call_tool("get_transactions_summary"))[0].text)
+    result = json.loads((await mcp_client.call_tool("get_transactions_summary")).content[0].text)
 
     assert "transactionsSummary" in result
     mock_monarch_client.get_transactions_summary.assert_called_once()
@@ -38,7 +38,7 @@ async def test_summary_happy(mcp_client, mock_monarch_client):
 async def test_summary_error(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions_summary.side_effect = Exception("API down")
 
-    result = (await mcp_client.call_tool("get_transactions_summary"))[0].text
+    result = (await mcp_client.call_tool("get_transactions_summary")).content[0].text
 
     assert "Error" in result
 
@@ -62,7 +62,7 @@ SAMPLE_SUBSCRIPTION = {
 async def test_subscription_happy(mcp_client, mock_monarch_client):
     mock_monarch_client.get_subscription_details.return_value = SAMPLE_SUBSCRIPTION
 
-    result = json.loads((await mcp_client.call_tool("get_subscription_details"))[0].text)
+    result = json.loads((await mcp_client.call_tool("get_subscription_details")).content[0].text)
 
     assert result["subscription"]["hasPremiumEntitlement"] is True
     mock_monarch_client.get_subscription_details.assert_called_once()
@@ -71,7 +71,7 @@ async def test_subscription_happy(mcp_client, mock_monarch_client):
 async def test_subscription_error(mcp_client, mock_monarch_client):
     mock_monarch_client.get_subscription_details.side_effect = Exception("API down")
 
-    result = (await mcp_client.call_tool("get_subscription_details"))[0].text
+    result = (await mcp_client.call_tool("get_subscription_details")).content[0].text
 
     assert "Error" in result
 
@@ -97,7 +97,7 @@ SAMPLE_INSTITUTIONS = {
 async def test_institutions_happy(mcp_client, mock_monarch_client):
     mock_monarch_client.get_institutions.return_value = SAMPLE_INSTITUTIONS
 
-    result = json.loads((await mcp_client.call_tool("get_institutions"))[0].text)
+    result = json.loads((await mcp_client.call_tool("get_institutions")).content[0].text)
 
     assert len(result["credentials"]) == 1
     assert result["credentials"][0]["institution"]["name"] == "Chase"
@@ -107,7 +107,7 @@ async def test_institutions_happy(mcp_client, mock_monarch_client):
 async def test_institutions_empty(mcp_client, mock_monarch_client):
     mock_monarch_client.get_institutions.return_value = {"credentials": []}
 
-    result = json.loads((await mcp_client.call_tool("get_institutions"))[0].text)
+    result = json.loads((await mcp_client.call_tool("get_institutions")).content[0].text)
 
     assert result["credentials"] == []
 
@@ -115,7 +115,7 @@ async def test_institutions_empty(mcp_client, mock_monarch_client):
 async def test_institutions_error(mcp_client, mock_monarch_client):
     mock_monarch_client.get_institutions.side_effect = Exception("API down")
 
-    result = (await mcp_client.call_tool("get_institutions"))[0].text
+    result = (await mcp_client.call_tool("get_institutions")).content[0].text
 
     assert "Error" in result
 
@@ -142,7 +142,7 @@ SAMPLE_CASHFLOW_SUMMARY = {
 async def test_cashflow_summary_no_dates(mcp_client, mock_monarch_client):
     mock_monarch_client.get_cashflow_summary.return_value = SAMPLE_CASHFLOW_SUMMARY
 
-    result = json.loads((await mcp_client.call_tool("get_cashflow_summary"))[0].text)
+    result = json.loads((await mcp_client.call_tool("get_cashflow_summary")).content[0].text)
 
     assert "summary" in result
     mock_monarch_client.get_cashflow_summary.assert_called_once_with(limit=100)
@@ -173,7 +173,7 @@ async def test_cashflow_summary_only_start_error(mcp_client):
     result = json.loads(
         (await mcp_client.call_tool(
             "get_cashflow_summary", {"start_date": "2025-01-01"}
-        ))[0].text
+        )).content[0].text
     )
     assert "error" in result
 
@@ -182,7 +182,7 @@ async def test_cashflow_summary_only_end_error(mcp_client):
     result = json.loads(
         (await mcp_client.call_tool(
             "get_cashflow_summary", {"end_date": "2025-01-31"}
-        ))[0].text
+        )).content[0].text
     )
     assert "error" in result
 
@@ -190,6 +190,6 @@ async def test_cashflow_summary_only_end_error(mcp_client):
 async def test_cashflow_summary_error(mcp_client, mock_monarch_client):
     mock_monarch_client.get_cashflow_summary.side_effect = Exception("API down")
 
-    result = (await mcp_client.call_tool("get_cashflow_summary"))[0].text
+    result = (await mcp_client.call_tool("get_cashflow_summary")).content[0].text
 
     assert "Error" in result

--- a/tests/test_recurring.py
+++ b/tests/test_recurring.py
@@ -30,7 +30,7 @@ async def test_recurring_no_dates(mcp_client, mock_monarch_client):
     mock_monarch_client.get_recurring_transactions.return_value = SAMPLE_RECURRING
 
     result = json.loads(
-        (await mcp_client.call_tool("get_recurring_transactions"))[0].text
+        (await mcp_client.call_tool("get_recurring_transactions")).content[0].text
     )
 
     assert len(result["recurringTransactions"]) == 2
@@ -54,7 +54,7 @@ async def test_recurring_only_start_error(mcp_client):
     result = json.loads(
         (await mcp_client.call_tool(
             "get_recurring_transactions", {"start_date": "2025-01-01"}
-        ))[0].text
+        )).content[0].text
     )
     assert "error" in result
 
@@ -63,7 +63,7 @@ async def test_recurring_only_end_error(mcp_client):
     result = json.loads(
         (await mcp_client.call_tool(
             "get_recurring_transactions", {"end_date": "2025-12-31"}
-        ))[0].text
+        )).content[0].text
     )
     assert "error" in result
 
@@ -74,7 +74,7 @@ async def test_recurring_empty(mcp_client, mock_monarch_client):
     }
 
     result = json.loads(
-        (await mcp_client.call_tool("get_recurring_transactions"))[0].text
+        (await mcp_client.call_tool("get_recurring_transactions")).content[0].text
     )
 
     assert result["recurringTransactions"] == []
@@ -83,6 +83,6 @@ async def test_recurring_empty(mcp_client, mock_monarch_client):
 async def test_recurring_error(mcp_client, mock_monarch_client):
     mock_monarch_client.get_recurring_transactions.side_effect = Exception("API down")
 
-    result = (await mcp_client.call_tool("get_recurring_transactions"))[0].text
+    result = (await mcp_client.call_tool("get_recurring_transactions")).content[0].text
 
     assert "Error" in result

--- a/tests/test_recurring.py
+++ b/tests/test_recurring.py
@@ -3,8 +3,6 @@
 
 import json
 
-from monarch_mcp_server.server import get_recurring_transactions
-
 
 SAMPLE_RECURRING = {
     "recurringTransactions": [
@@ -28,48 +26,63 @@ SAMPLE_RECURRING = {
 }
 
 
-def test_recurring_no_dates(mock_monarch_client):
+async def test_recurring_no_dates(mcp_client, mock_monarch_client):
     mock_monarch_client.get_recurring_transactions.return_value = SAMPLE_RECURRING
 
-    result = json.loads(get_recurring_transactions())
+    result = json.loads(
+        (await mcp_client.call_tool("get_recurring_transactions"))[0].text
+    )
 
     assert len(result["recurringTransactions"]) == 2
     mock_monarch_client.get_recurring_transactions.assert_called_once_with()
 
 
-def test_recurring_with_dates(mock_monarch_client):
+async def test_recurring_with_dates(mcp_client, mock_monarch_client):
     mock_monarch_client.get_recurring_transactions.return_value = SAMPLE_RECURRING
 
-    get_recurring_transactions(start_date="2025-01-01", end_date="2025-12-31")
+    await mcp_client.call_tool(
+        "get_recurring_transactions",
+        {"start_date": "2025-01-01", "end_date": "2025-12-31"},
+    )
 
     mock_monarch_client.get_recurring_transactions.assert_called_once_with(
         start_date="2025-01-01", end_date="2025-12-31"
     )
 
 
-def test_recurring_only_start_error():
-    result = json.loads(get_recurring_transactions(start_date="2025-01-01"))
+async def test_recurring_only_start_error(mcp_client):
+    result = json.loads(
+        (await mcp_client.call_tool(
+            "get_recurring_transactions", {"start_date": "2025-01-01"}
+        ))[0].text
+    )
     assert "error" in result
 
 
-def test_recurring_only_end_error():
-    result = json.loads(get_recurring_transactions(end_date="2025-12-31"))
+async def test_recurring_only_end_error(mcp_client):
+    result = json.loads(
+        (await mcp_client.call_tool(
+            "get_recurring_transactions", {"end_date": "2025-12-31"}
+        ))[0].text
+    )
     assert "error" in result
 
 
-def test_recurring_empty(mock_monarch_client):
+async def test_recurring_empty(mcp_client, mock_monarch_client):
     mock_monarch_client.get_recurring_transactions.return_value = {
         "recurringTransactions": []
     }
 
-    result = json.loads(get_recurring_transactions())
+    result = json.loads(
+        (await mcp_client.call_tool("get_recurring_transactions"))[0].text
+    )
 
     assert result["recurringTransactions"] == []
 
 
-def test_recurring_error(mock_monarch_client):
+async def test_recurring_error(mcp_client, mock_monarch_client):
     mock_monarch_client.get_recurring_transactions.side_effect = Exception("API down")
 
-    result = get_recurring_transactions()
+    result = (await mcp_client.call_tool("get_recurring_transactions"))[0].text
 
     assert "Error" in result

--- a/tests/test_server_edge_cases.py
+++ b/tests/test_server_edge_cases.py
@@ -87,14 +87,14 @@ def test_get_client_no_credentials(mock_monarch_client, monkeypatch):
 async def test_check_auth_no_token(mcp_client):
     with patch("monarch_mcp_server.secure_session.keyring") as mock_kr:
         mock_kr.get_password.return_value = None
-        result = (await mcp_client.call_tool("check_auth_status"))[0].text
+        result = (await mcp_client.call_tool("check_auth_status")).content[0].text
 
     assert "No authentication token" in result
 
 
 async def test_check_auth_with_env_email(mcp_client, monkeypatch):
     monkeypatch.setenv("MONARCH_EMAIL", "user@test.com")
-    result = (await mcp_client.call_tool("check_auth_status"))[0].text
+    result = (await mcp_client.call_tool("check_auth_status")).content[0].text
 
     assert "user@test.com" in result
 
@@ -102,7 +102,7 @@ async def test_check_auth_with_env_email(mcp_client, monkeypatch):
 async def test_check_auth_exception(mcp_client):
     with patch("monarch_mcp_server.server.secure_session") as mock_ss:
         mock_ss.load_token.side_effect = RuntimeError("boom")
-        result = (await mcp_client.call_tool("check_auth_status"))[0].text
+        result = (await mcp_client.call_tool("check_auth_status")).content[0].text
 
     assert "Error checking auth status" in result
 
@@ -115,7 +115,7 @@ async def test_check_auth_exception(mcp_client):
 async def test_debug_session_no_token(mcp_client):
     with patch("monarch_mcp_server.secure_session.keyring") as mock_kr:
         mock_kr.get_password.return_value = None
-        result = (await mcp_client.call_tool("debug_session_loading"))[0].text
+        result = (await mcp_client.call_tool("debug_session_loading")).content[0].text
 
     assert "No token found" in result
 
@@ -123,7 +123,7 @@ async def test_debug_session_no_token(mcp_client):
 async def test_debug_session_exception(mcp_client):
     with patch("monarch_mcp_server.server.secure_session") as mock_ss:
         mock_ss.load_token.side_effect = RuntimeError("keyring busted")
-        result = (await mcp_client.call_tool("debug_session_loading"))[0].text
+        result = (await mcp_client.call_tool("debug_session_loading")).content[0].text
 
     assert "Keyring access failed" in result
 
@@ -139,7 +139,7 @@ async def test_update_transaction_goal_id(mcp_write_client, mock_monarch_client)
     result = json.loads(
         (await mcp_write_client.call_tool(
             "update_transaction", {"transaction_id": "txn-1", "goal_id": "goal-42"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["ok"] is True
@@ -156,7 +156,7 @@ async def test_refresh_accounts_empty(mcp_client, mock_monarch_client):
     mock_monarch_client.get_accounts.return_value = {"accounts": []}
 
     result = json.loads(
-        (await mcp_client.call_tool("refresh_accounts"))[0].text
+        (await mcp_client.call_tool("refresh_accounts")).content[0].text
     )
 
     assert "error" in result

--- a/tests/test_tag_crud.py
+++ b/tests/test_tag_crud.py
@@ -21,7 +21,7 @@ async def test_list_tags(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transaction_tags.return_value = SAMPLE_TAGS_RESPONSE
 
     result = json.loads(
-        (await mcp_client.call_tool("get_transaction_tags"))[0].text
+        (await mcp_client.call_tool("get_transaction_tags")).content[0].text
     )
 
     assert len(result) == 2
@@ -44,7 +44,7 @@ async def test_create_tag_happy(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "create_transaction_tag", {"name": "Travel", "color": "#19D2A5"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["id"] == "tag-new"
@@ -62,7 +62,7 @@ async def test_create_tag_invalid_color_word(mcp_write_client, mock_monarch_clie
     result = json.loads(
         (await mcp_write_client.call_tool(
             "create_transaction_tag", {"name": "Test", "color": "red"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert "error" in result
@@ -78,7 +78,7 @@ async def test_create_tag_short_hex(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "create_transaction_tag", {"name": "Test", "color": "#F00"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert "error" in result
@@ -94,7 +94,7 @@ async def test_create_tag_empty_name(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "create_transaction_tag", {"name": "", "color": "#19D2A5"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert "error" in result
@@ -110,7 +110,7 @@ async def test_create_tag_whitespace_name(mcp_write_client, mock_monarch_client)
     result = json.loads(
         (await mcp_write_client.call_tool(
             "create_transaction_tag", {"name": "   ", "color": "#19D2A5"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert "error" in result
@@ -132,7 +132,7 @@ async def test_create_tag_duplicate_name(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "create_transaction_tag", {"name": "Vacation", "color": "#19D2A5"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["id"] == "tag-dup"
@@ -154,7 +154,7 @@ async def test_create_tag_unicode_name(mcp_write_client, mock_monarch_client):
         (await mcp_write_client.call_tool(
             "create_transaction_tag",
             {"name": "\u65c5\u884c\u2708\ufe0f", "color": "#AABBCC"},
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["name"] == "\u65c5\u884c\u2708\ufe0f"
@@ -176,7 +176,7 @@ async def test_create_tag_long_name(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "create_transaction_tag", {"name": long_name, "color": "#112233"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["name"] == long_name
@@ -198,7 +198,7 @@ async def test_create_tag_special_chars(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "create_transaction_tag", {"name": special, "color": "#ABCDEF"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["name"] == special
@@ -217,7 +217,7 @@ async def test_delete_tag_happy(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "delete_transaction_tag", {"tag_id": "tag-123"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["deleted"] is True
@@ -238,7 +238,7 @@ async def test_delete_tag_invalid_id(mcp_write_client, mock_monarch_client):
 
     result = (await mcp_write_client.call_tool(
         "delete_transaction_tag", {"tag_id": "bad-id"}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
     assert "Tag not found" in result
@@ -254,6 +254,6 @@ async def test_delete_tag_already_deleted(mcp_write_client, mock_monarch_client)
 
     result = (await mcp_write_client.call_tool(
         "delete_transaction_tag", {"tag_id": "tag-gone"}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result

--- a/tests/test_transaction_crud.py
+++ b/tests/test_transaction_crud.py
@@ -43,7 +43,7 @@ async def test_create_happy(mcp_write_client, mock_monarch_client):
                 "date": "2025-01-15",
                 "notes": "Morning coffee",
             },
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["id"] == "txn-new"
@@ -71,7 +71,7 @@ async def test_create_positive_amount(mcp_write_client, mock_monarch_client):
                 "category_id": "cat-income",
                 "date": "2025-01-15",
             },
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["amount"] == 500.00
@@ -110,7 +110,7 @@ async def test_create_invalid_account(mcp_write_client, mock_monarch_client):
             "category_id": "cat-1",
             "date": "2025-01-15",
         },
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
     assert "Account not found" in result
@@ -130,7 +130,7 @@ async def test_create_invalid_category(mcp_write_client, mock_monarch_client):
             "category_id": "bad-cat",
             "date": "2025-01-15",
         },
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
     assert "Category not found" in result
@@ -148,7 +148,7 @@ async def test_create_invalid_date(mcp_write_client, mock_monarch_client):
             "category_id": "cat-1",
             "date": "not-a-date",
         },
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
 
@@ -166,7 +166,7 @@ async def test_create_zero_amount(mcp_write_client, mock_monarch_client):
                 "category_id": "cat-1",
                 "date": "2025-01-15",
             },
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["amount"] == 0.0
@@ -186,7 +186,7 @@ async def test_create_large_amount(mcp_write_client, mock_monarch_client):
                 "category_id": "cat-1",
                 "date": "2025-01-15",
             },
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["amount"] == big
@@ -208,7 +208,7 @@ async def test_create_unicode_merchant(mcp_write_client, mock_monarch_client):
                 "category_id": "cat-1",
                 "date": "2025-01-15",
             },
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["merchant"]["name"] == name
@@ -262,7 +262,7 @@ async def test_update_notes(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "update_transaction", {"transaction_id": "txn-1", "notes": "Updated note"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["notes"] == "Updated note"
@@ -277,7 +277,7 @@ async def test_update_noop(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "update_transaction", {"transaction_id": "txn-1"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["id"] == "txn-1"
@@ -291,7 +291,7 @@ async def test_update_amount(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "update_transaction", {"transaction_id": "txn-1", "amount": -99.99}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["amount"] == -99.99
@@ -307,7 +307,7 @@ async def test_update_merchant(mcp_write_client, mock_monarch_client):
         (await mcp_write_client.call_tool(
             "update_transaction",
             {"transaction_id": "txn-1", "merchant_name": "New Name"},
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["merchant"]["name"] == "New Name"
@@ -319,7 +319,7 @@ async def test_update_date(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "update_transaction", {"transaction_id": "txn-1", "date": "2025-06-15"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["date"] == "2025-06-15"
@@ -335,7 +335,7 @@ async def test_update_hide_from_reports(mcp_write_client, mock_monarch_client):
         (await mcp_write_client.call_tool(
             "update_transaction",
             {"transaction_id": "txn-1", "hide_from_reports": True},
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["hideFromReports"] is True
@@ -353,7 +353,7 @@ async def test_update_needs_review(mcp_write_client, mock_monarch_client):
         (await mcp_write_client.call_tool(
             "update_transaction",
             {"transaction_id": "txn-1", "needs_review": False},
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["needsReview"] is False
@@ -376,7 +376,7 @@ async def test_update_multi_field(mcp_write_client, mock_monarch_client):
                 "notes": "multi",
                 "date": "2025-02-01",
             },
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["amount"] == -25.0
@@ -397,7 +397,7 @@ async def test_update_category(mcp_write_client, mock_monarch_client):
         (await mcp_write_client.call_tool(
             "update_transaction",
             {"transaction_id": "txn-1", "category_id": "cat-2"},
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["category"]["name"] == "Groceries"
@@ -412,7 +412,7 @@ async def test_update_invalid_id(mcp_write_client, mock_monarch_client):
 
     result = (await mcp_write_client.call_tool(
         "update_transaction", {"transaction_id": "bad-id", "notes": "x"}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
     assert "Transaction not found" in result
@@ -423,7 +423,7 @@ async def test_update_invalid_date(mcp_write_client, mock_monarch_client):
 
     result = (await mcp_write_client.call_tool(
         "update_transaction", {"transaction_id": "txn-1", "date": "nope"}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
 
@@ -438,7 +438,7 @@ async def test_update_long_notes(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "update_transaction", {"transaction_id": "txn-1", "notes": long_note}
-        ))[0].text
+        )).content[0].text
     )
 
     assert len(result["notes"]) == 5000
@@ -459,7 +459,7 @@ async def test_update_html_xss_merchant(mcp_write_client, mock_monarch_client):
             "transaction_id": "txn-1",
             "merchant_name": "<script>alert('xss')</script>",
         },
-    ))[0].text
+    )).content[0].text
 
     # WAF 403 is NOT treated as auth error — just passed through as tool error
     assert "Error" in result
@@ -476,7 +476,7 @@ async def test_delete_happy(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "delete_transaction", {"transaction_id": "txn-1"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["deleted"] is True
@@ -491,7 +491,7 @@ async def test_delete_invalid_id(mcp_write_client, mock_monarch_client):
 
     result = (await mcp_write_client.call_tool(
         "delete_transaction", {"transaction_id": "bad-id"}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
     assert "Transaction not found" in result
@@ -504,6 +504,6 @@ async def test_delete_already_deleted(mcp_write_client, mock_monarch_client):
 
     result = (await mcp_write_client.call_tool(
         "delete_transaction", {"transaction_id": "txn-gone"}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result

--- a/tests/test_transaction_crud.py
+++ b/tests/test_transaction_crud.py
@@ -5,12 +5,6 @@ import json
 
 from gql.transport.exceptions import TransportServerError
 
-from monarch_mcp_server.server import (
-    create_transaction,
-    update_transaction,
-    delete_transaction,
-)
-
 
 # ===================================================================
 # Helpers
@@ -35,18 +29,21 @@ def _api_txn(**overrides):
 # ===================================================================
 
 
-def test_create_happy(mock_monarch_client):
+async def test_create_happy(mcp_write_client, mock_monarch_client):
     mock_monarch_client.create_transaction.return_value = _api_txn()
 
     result = json.loads(
-        create_transaction(
-            account_id="acc-1",
-            amount=-42.50,
-            merchant_name="Coffee Shop",
-            category_id="cat-1",
-            date="2025-01-15",
-            notes="Morning coffee",
-        )
+        (await mcp_write_client.call_tool(
+            "create_transaction",
+            {
+                "account_id": "acc-1",
+                "amount": -42.50,
+                "merchant_name": "Coffee Shop",
+                "category_id": "cat-1",
+                "date": "2025-01-15",
+                "notes": "Morning coffee",
+            },
+        ))[0].text
     )
 
     assert result["id"] == "txn-new"
@@ -61,31 +58,37 @@ def test_create_happy(mock_monarch_client):
     )
 
 
-def test_create_positive_amount(mock_monarch_client):
+async def test_create_positive_amount(mcp_write_client, mock_monarch_client):
     mock_monarch_client.create_transaction.return_value = _api_txn(amount=500.00)
 
     result = json.loads(
-        create_transaction(
-            account_id="acc-1",
-            amount=500.00,
-            merchant_name="Employer",
-            category_id="cat-income",
-            date="2025-01-15",
-        )
+        (await mcp_write_client.call_tool(
+            "create_transaction",
+            {
+                "account_id": "acc-1",
+                "amount": 500.00,
+                "merchant_name": "Employer",
+                "category_id": "cat-income",
+                "date": "2025-01-15",
+            },
+        ))[0].text
     )
 
     assert result["amount"] == 500.00
 
 
-def test_create_no_notes(mock_monarch_client):
+async def test_create_no_notes(mcp_write_client, mock_monarch_client):
     mock_monarch_client.create_transaction.return_value = _api_txn()
 
-    create_transaction(
-        account_id="acc-1",
-        amount=-10.0,
-        merchant_name="Store",
-        category_id="cat-1",
-        date="2025-01-15",
+    await mcp_write_client.call_tool(
+        "create_transaction",
+        {
+            "account_id": "acc-1",
+            "amount": -10.0,
+            "merchant_name": "Store",
+            "category_id": "cat-1",
+            "date": "2025-01-15",
+        },
     )
 
     # notes defaults to "" when not provided
@@ -93,131 +96,155 @@ def test_create_no_notes(mock_monarch_client):
     assert call_kwargs["notes"] == ""
 
 
-def test_create_invalid_account(mock_monarch_client):
+async def test_create_invalid_account(mcp_write_client, mock_monarch_client):
     mock_monarch_client.create_transaction.side_effect = Exception(
         "Account not found"
     )
 
-    result = create_transaction(
-        account_id="bad-acc",
-        amount=-10.0,
-        merchant_name="Store",
-        category_id="cat-1",
-        date="2025-01-15",
-    )
+    result = (await mcp_write_client.call_tool(
+        "create_transaction",
+        {
+            "account_id": "bad-acc",
+            "amount": -10.0,
+            "merchant_name": "Store",
+            "category_id": "cat-1",
+            "date": "2025-01-15",
+        },
+    ))[0].text
 
     assert "Error" in result
     assert "Account not found" in result
 
 
-def test_create_invalid_category(mock_monarch_client):
+async def test_create_invalid_category(mcp_write_client, mock_monarch_client):
     mock_monarch_client.create_transaction.side_effect = Exception(
         "Category not found"
     )
 
-    result = create_transaction(
-        account_id="acc-1",
-        amount=-10.0,
-        merchant_name="Store",
-        category_id="bad-cat",
-        date="2025-01-15",
-    )
+    result = (await mcp_write_client.call_tool(
+        "create_transaction",
+        {
+            "account_id": "acc-1",
+            "amount": -10.0,
+            "merchant_name": "Store",
+            "category_id": "bad-cat",
+            "date": "2025-01-15",
+        },
+    ))[0].text
 
     assert "Error" in result
     assert "Category not found" in result
 
 
-def test_create_invalid_date(mock_monarch_client):
+async def test_create_invalid_date(mcp_write_client, mock_monarch_client):
     mock_monarch_client.create_transaction.side_effect = Exception("Invalid date")
 
-    result = create_transaction(
-        account_id="acc-1",
-        amount=-10.0,
-        merchant_name="Store",
-        category_id="cat-1",
-        date="not-a-date",
-    )
+    result = (await mcp_write_client.call_tool(
+        "create_transaction",
+        {
+            "account_id": "acc-1",
+            "amount": -10.0,
+            "merchant_name": "Store",
+            "category_id": "cat-1",
+            "date": "not-a-date",
+        },
+    ))[0].text
 
     assert "Error" in result
 
 
-def test_create_zero_amount(mock_monarch_client):
+async def test_create_zero_amount(mcp_write_client, mock_monarch_client):
     mock_monarch_client.create_transaction.return_value = _api_txn(amount=0.0)
 
     result = json.loads(
-        create_transaction(
-            account_id="acc-1",
-            amount=0.0,
-            merchant_name="Adjustment",
-            category_id="cat-1",
-            date="2025-01-15",
-        )
+        (await mcp_write_client.call_tool(
+            "create_transaction",
+            {
+                "account_id": "acc-1",
+                "amount": 0.0,
+                "merchant_name": "Adjustment",
+                "category_id": "cat-1",
+                "date": "2025-01-15",
+            },
+        ))[0].text
     )
 
     assert result["amount"] == 0.0
 
 
-def test_create_large_amount(mock_monarch_client):
+async def test_create_large_amount(mcp_write_client, mock_monarch_client):
     big = 9999999.99
     mock_monarch_client.create_transaction.return_value = _api_txn(amount=big)
 
     result = json.loads(
-        create_transaction(
-            account_id="acc-1",
-            amount=big,
-            merchant_name="Mega Corp",
-            category_id="cat-1",
-            date="2025-01-15",
-        )
+        (await mcp_write_client.call_tool(
+            "create_transaction",
+            {
+                "account_id": "acc-1",
+                "amount": big,
+                "merchant_name": "Mega Corp",
+                "category_id": "cat-1",
+                "date": "2025-01-15",
+            },
+        ))[0].text
     )
 
     assert result["amount"] == big
 
 
-def test_create_unicode_merchant(mock_monarch_client):
+async def test_create_unicode_merchant(mcp_write_client, mock_monarch_client):
     name = "\u5496\u5561\u5e97 \u2615"
     mock_monarch_client.create_transaction.return_value = _api_txn(
         merchant={"name": name}
     )
 
     result = json.loads(
-        create_transaction(
-            account_id="acc-1",
-            amount=-5.0,
-            merchant_name=name,
-            category_id="cat-1",
-            date="2025-01-15",
-        )
+        (await mcp_write_client.call_tool(
+            "create_transaction",
+            {
+                "account_id": "acc-1",
+                "amount": -5.0,
+                "merchant_name": name,
+                "category_id": "cat-1",
+                "date": "2025-01-15",
+            },
+        ))[0].text
     )
 
     assert result["merchant"]["name"] == name
 
 
-def test_create_with_update_balance(mock_monarch_client):
+async def test_create_with_update_balance(mcp_write_client, mock_monarch_client):
     mock_monarch_client.create_transaction.return_value = _api_txn()
 
-    create_transaction(
-        account_id="acc-1",
-        amount=-42.50,
-        merchant_name="Coffee Shop",
-        category_id="cat-1",
-        date="2025-01-15",
-        update_balance=True,
+    await mcp_write_client.call_tool(
+        "create_transaction",
+        {
+            "account_id": "acc-1",
+            "amount": -42.50,
+            "merchant_name": "Coffee Shop",
+            "category_id": "cat-1",
+            "date": "2025-01-15",
+            "update_balance": True,
+        },
     )
 
     call_kwargs = mock_monarch_client.create_transaction.call_args[1]
     assert call_kwargs["update_balance"] is True
 
 
-def test_create_default_update_balance(mock_monarch_client):
+async def test_create_default_update_balance(mcp_write_client, mock_monarch_client):
     mock_monarch_client.create_transaction.return_value = _api_txn()
 
-    create_transaction(
-        account_id="acc-1",
-        amount=-10.0,
-        merchant_name="Store",
-        category_id="cat-1",
-        date="2025-01-15",
+    await mcp_write_client.call_tool(
+        "create_transaction",
+        {
+            "account_id": "acc-1",
+            "amount": -10.0,
+            "merchant_name": "Store",
+            "category_id": "cat-1",
+            "date": "2025-01-15",
+        },
     )
 
     call_kwargs = mock_monarch_client.create_transaction.call_args[1]
@@ -229,11 +256,13 @@ def test_create_default_update_balance(mock_monarch_client):
 # ===================================================================
 
 
-def test_update_notes(mock_monarch_client):
+async def test_update_notes(mcp_write_client, mock_monarch_client):
     mock_monarch_client.update_transaction.return_value = {"id": "txn-1", "notes": "Updated note"}
 
     result = json.loads(
-        update_transaction(transaction_id="txn-1", notes="Updated note")
+        (await mcp_write_client.call_tool(
+            "update_transaction", {"transaction_id": "txn-1", "notes": "Updated note"}
+        ))[0].text
     )
 
     assert result["notes"] == "Updated note"
@@ -242,57 +271,71 @@ def test_update_notes(mock_monarch_client):
     assert call_kwargs["transaction_id"] == "txn-1"
 
 
-def test_update_noop(mock_monarch_client):
+async def test_update_noop(mcp_write_client, mock_monarch_client):
     mock_monarch_client.update_transaction.return_value = {"id": "txn-1"}
 
-    result = json.loads(update_transaction(transaction_id="txn-1"))
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "update_transaction", {"transaction_id": "txn-1"}
+        ))[0].text
+    )
 
     assert result["id"] == "txn-1"
     call_kwargs = mock_monarch_client.update_transaction.call_args[1]
     assert call_kwargs == {"transaction_id": "txn-1"}
 
 
-def test_update_amount(mock_monarch_client):
+async def test_update_amount(mcp_write_client, mock_monarch_client):
     mock_monarch_client.update_transaction.return_value = {"id": "txn-1", "amount": -99.99}
 
     result = json.loads(
-        update_transaction(transaction_id="txn-1", amount=-99.99)
+        (await mcp_write_client.call_tool(
+            "update_transaction", {"transaction_id": "txn-1", "amount": -99.99}
+        ))[0].text
     )
 
     assert result["amount"] == -99.99
 
 
-def test_update_merchant(mock_monarch_client):
+async def test_update_merchant(mcp_write_client, mock_monarch_client):
     mock_monarch_client.update_transaction.return_value = {
         "id": "txn-1",
         "merchant": {"name": "New Name"},
     }
 
     result = json.loads(
-        update_transaction(transaction_id="txn-1", merchant_name="New Name")
+        (await mcp_write_client.call_tool(
+            "update_transaction",
+            {"transaction_id": "txn-1", "merchant_name": "New Name"},
+        ))[0].text
     )
 
     assert result["merchant"]["name"] == "New Name"
 
 
-def test_update_date(mock_monarch_client):
+async def test_update_date(mcp_write_client, mock_monarch_client):
     mock_monarch_client.update_transaction.return_value = {"id": "txn-1", "date": "2025-06-15"}
 
     result = json.loads(
-        update_transaction(transaction_id="txn-1", date="2025-06-15")
+        (await mcp_write_client.call_tool(
+            "update_transaction", {"transaction_id": "txn-1", "date": "2025-06-15"}
+        ))[0].text
     )
 
     assert result["date"] == "2025-06-15"
 
 
-def test_update_hide_from_reports(mock_monarch_client):
+async def test_update_hide_from_reports(mcp_write_client, mock_monarch_client):
     mock_monarch_client.update_transaction.return_value = {
         "id": "txn-1",
         "hideFromReports": True,
     }
 
     result = json.loads(
-        update_transaction(transaction_id="txn-1", hide_from_reports=True)
+        (await mcp_write_client.call_tool(
+            "update_transaction",
+            {"transaction_id": "txn-1", "hide_from_reports": True},
+        ))[0].text
     )
 
     assert result["hideFromReports"] is True
@@ -300,20 +343,23 @@ def test_update_hide_from_reports(mock_monarch_client):
     assert call_kwargs["hide_from_reports"] is True
 
 
-def test_update_needs_review(mock_monarch_client):
+async def test_update_needs_review(mcp_write_client, mock_monarch_client):
     mock_monarch_client.update_transaction.return_value = {
         "id": "txn-1",
         "needsReview": False,
     }
 
     result = json.loads(
-        update_transaction(transaction_id="txn-1", needs_review=False)
+        (await mcp_write_client.call_tool(
+            "update_transaction",
+            {"transaction_id": "txn-1", "needs_review": False},
+        ))[0].text
     )
 
     assert result["needsReview"] is False
 
 
-def test_update_multi_field(mock_monarch_client):
+async def test_update_multi_field(mcp_write_client, mock_monarch_client):
     mock_monarch_client.update_transaction.return_value = {
         "id": "txn-1",
         "amount": -25.0,
@@ -322,9 +368,15 @@ def test_update_multi_field(mock_monarch_client):
     }
 
     result = json.loads(
-        update_transaction(
-            transaction_id="txn-1", amount=-25.0, notes="multi", date="2025-02-01"
-        )
+        (await mcp_write_client.call_tool(
+            "update_transaction",
+            {
+                "transaction_id": "txn-1",
+                "amount": -25.0,
+                "notes": "multi",
+                "date": "2025-02-01",
+            },
+        ))[0].text
     )
 
     assert result["amount"] == -25.0
@@ -335,14 +387,17 @@ def test_update_multi_field(mock_monarch_client):
     assert call_kwargs["date"] == "2025-02-01"
 
 
-def test_update_category(mock_monarch_client):
+async def test_update_category(mcp_write_client, mock_monarch_client):
     mock_monarch_client.update_transaction.return_value = {
         "id": "txn-1",
         "category": {"id": "cat-2", "name": "Groceries"},
     }
 
     result = json.loads(
-        update_transaction(transaction_id="txn-1", category_id="cat-2")
+        (await mcp_write_client.call_tool(
+            "update_transaction",
+            {"transaction_id": "txn-1", "category_id": "cat-2"},
+        ))[0].text
     )
 
     assert result["category"]["name"] == "Groceries"
@@ -350,26 +405,30 @@ def test_update_category(mock_monarch_client):
     assert call_kwargs["category_id"] == "cat-2"
 
 
-def test_update_invalid_id(mock_monarch_client):
+async def test_update_invalid_id(mcp_write_client, mock_monarch_client):
     mock_monarch_client.update_transaction.side_effect = Exception(
         "Transaction not found"
     )
 
-    result = update_transaction(transaction_id="bad-id", notes="x")
+    result = (await mcp_write_client.call_tool(
+        "update_transaction", {"transaction_id": "bad-id", "notes": "x"}
+    ))[0].text
 
     assert "Error" in result
     assert "Transaction not found" in result
 
 
-def test_update_invalid_date(mock_monarch_client):
+async def test_update_invalid_date(mcp_write_client, mock_monarch_client):
     mock_monarch_client.update_transaction.side_effect = Exception("Invalid date")
 
-    result = update_transaction(transaction_id="txn-1", date="nope")
+    result = (await mcp_write_client.call_tool(
+        "update_transaction", {"transaction_id": "txn-1", "date": "nope"}
+    ))[0].text
 
     assert "Error" in result
 
 
-def test_update_long_notes(mock_monarch_client):
+async def test_update_long_notes(mcp_write_client, mock_monarch_client):
     long_note = "N" * 5000
     mock_monarch_client.update_transaction.return_value = {
         "id": "txn-1",
@@ -377,13 +436,15 @@ def test_update_long_notes(mock_monarch_client):
     }
 
     result = json.loads(
-        update_transaction(transaction_id="txn-1", notes=long_note)
+        (await mcp_write_client.call_tool(
+            "update_transaction", {"transaction_id": "txn-1", "notes": long_note}
+        ))[0].text
     )
 
     assert len(result["notes"]) == 5000
 
 
-def test_update_html_xss_merchant(mock_monarch_client):
+async def test_update_html_xss_merchant(mcp_write_client, mock_monarch_client):
     """WAF blocks HTML-like merchant names with 403 + text/html."""
     cause = Exception("403 Forbidden")
     cause.headers = {"content-type": "text/html"}
@@ -392,10 +453,13 @@ def test_update_html_xss_merchant(mock_monarch_client):
 
     mock_monarch_client.update_transaction.side_effect = exc
 
-    result = update_transaction(
-        transaction_id="txn-1",
-        merchant_name="<script>alert('xss')</script>",
-    )
+    result = (await mcp_write_client.call_tool(
+        "update_transaction",
+        {
+            "transaction_id": "txn-1",
+            "merchant_name": "<script>alert('xss')</script>",
+        },
+    ))[0].text
 
     # WAF 403 is NOT treated as auth error — just passed through as tool error
     assert "Error" in result
@@ -406,32 +470,40 @@ def test_update_html_xss_merchant(mock_monarch_client):
 # ===================================================================
 
 
-def test_delete_happy(mock_monarch_client):
+async def test_delete_happy(mcp_write_client, mock_monarch_client):
     mock_monarch_client.delete_transaction.return_value = None
 
-    result = json.loads(delete_transaction(transaction_id="txn-1"))
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "delete_transaction", {"transaction_id": "txn-1"}
+        ))[0].text
+    )
 
     assert result["deleted"] is True
     assert result["transaction_id"] == "txn-1"
     mock_monarch_client.delete_transaction.assert_called_once_with("txn-1")
 
 
-def test_delete_invalid_id(mock_monarch_client):
+async def test_delete_invalid_id(mcp_write_client, mock_monarch_client):
     mock_monarch_client.delete_transaction.side_effect = Exception(
         "Transaction not found"
     )
 
-    result = delete_transaction(transaction_id="bad-id")
+    result = (await mcp_write_client.call_tool(
+        "delete_transaction", {"transaction_id": "bad-id"}
+    ))[0].text
 
     assert "Error" in result
     assert "Transaction not found" in result
 
 
-def test_delete_already_deleted(mock_monarch_client):
+async def test_delete_already_deleted(mcp_write_client, mock_monarch_client):
     mock_monarch_client.delete_transaction.side_effect = Exception(
         "Transaction does not exist"
     )
 
-    result = delete_transaction(transaction_id="txn-gone")
+    result = (await mcp_write_client.call_tool(
+        "delete_transaction", {"transaction_id": "txn-gone"}
+    ))[0].text
 
     assert "Error" in result

--- a/tests/test_transaction_details.py
+++ b/tests/test_transaction_details.py
@@ -25,7 +25,7 @@ async def test_details_happy(mcp_client, mock_monarch_client):
     result = json.loads(
         (await mcp_client.call_tool(
             "get_transaction_details", {"transaction_id": "txn-1"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["getTransaction"]["id"] == "txn-1"
@@ -54,7 +54,7 @@ async def test_details_not_found(mcp_client, mock_monarch_client):
 
     result = (await mcp_client.call_tool(
         "get_transaction_details", {"transaction_id": "bad-id"}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
     assert "Transaction not found" in result
@@ -82,7 +82,7 @@ async def test_details_full_data(mcp_client, mock_monarch_client):
     result = json.loads(
         (await mcp_client.call_tool(
             "get_transaction_details", {"transaction_id": "txn-1"}
-        ))[0].text
+        )).content[0].text
     )
 
     txn = result["getTransaction"]

--- a/tests/test_transaction_details.py
+++ b/tests/test_transaction_details.py
@@ -3,8 +3,6 @@
 
 import json
 
-from monarch_mcp_server.server import get_transaction_details
-
 
 SAMPLE_DETAILS = {
     "getTransaction": {
@@ -21,10 +19,14 @@ SAMPLE_DETAILS = {
 }
 
 
-def test_details_happy(mock_monarch_client):
+async def test_details_happy(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transaction_details.return_value = SAMPLE_DETAILS
 
-    result = json.loads(get_transaction_details(transaction_id="txn-1"))
+    result = json.loads(
+        (await mcp_client.call_tool(
+            "get_transaction_details", {"transaction_id": "txn-1"}
+        ))[0].text
+    )
 
     assert result["getTransaction"]["id"] == "txn-1"
     mock_monarch_client.get_transaction_details.assert_called_once_with(
@@ -32,28 +34,33 @@ def test_details_happy(mock_monarch_client):
     )
 
 
-def test_details_no_redirect(mock_monarch_client):
+async def test_details_no_redirect(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transaction_details.return_value = SAMPLE_DETAILS
 
-    get_transaction_details(transaction_id="txn-1", redirect_posted=False)
+    await mcp_client.call_tool(
+        "get_transaction_details",
+        {"transaction_id": "txn-1", "redirect_posted": False},
+    )
 
     mock_monarch_client.get_transaction_details.assert_called_once_with(
         "txn-1", redirect_posted=False,
     )
 
 
-def test_details_not_found(mock_monarch_client):
+async def test_details_not_found(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transaction_details.side_effect = Exception(
         "Transaction not found"
     )
 
-    result = get_transaction_details(transaction_id="bad-id")
+    result = (await mcp_client.call_tool(
+        "get_transaction_details", {"transaction_id": "bad-id"}
+    ))[0].text
 
     assert "Error" in result
     assert "Transaction not found" in result
 
 
-def test_details_full_data(mock_monarch_client):
+async def test_details_full_data(mcp_client, mock_monarch_client):
     full = {
         "getTransaction": {
             "id": "txn-1",
@@ -72,7 +79,11 @@ def test_details_full_data(mock_monarch_client):
     }
     mock_monarch_client.get_transaction_details.return_value = full
 
-    result = json.loads(get_transaction_details(transaction_id="txn-1"))
+    result = json.loads(
+        (await mcp_client.call_tool(
+            "get_transaction_details", {"transaction_id": "txn-1"}
+        ))[0].text
+    )
 
     txn = result["getTransaction"]
     assert len(txn["attachments"]) == 1

--- a/tests/test_transaction_splits.py
+++ b/tests/test_transaction_splits.py
@@ -26,7 +26,7 @@ async def test_get_splits_happy(mcp_client, mock_monarch_client):
     result = json.loads(
         (await mcp_client.call_tool(
             "get_transaction_splits", {"transaction_id": "txn-1"}
-        ))[0].text
+        )).content[0].text
     )
 
     splits = result["getTransaction"]["splitTransactions"]
@@ -42,7 +42,7 @@ async def test_get_splits_empty(mcp_client, mock_monarch_client):
     result = json.loads(
         (await mcp_client.call_tool(
             "get_transaction_splits", {"transaction_id": "txn-1"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result["getTransaction"]["splitTransactions"] == []
@@ -55,7 +55,7 @@ async def test_get_splits_error(mcp_client, mock_monarch_client):
 
     result = (await mcp_client.call_tool(
         "get_transaction_splits", {"transaction_id": "bad-id"}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
 
@@ -78,7 +78,7 @@ async def test_update_splits_happy(mcp_write_client, mock_monarch_client):
         (await mcp_write_client.call_tool(
             "update_transaction_splits",
             {"transaction_id": "txn-1", "split_data": split_data},
-        ))[0].text
+        )).content[0].text
     )
 
     assert "updateTransactionSplits" in result
@@ -96,7 +96,7 @@ async def test_update_splits_remove_all(mcp_write_client, mock_monarch_client):
         (await mcp_write_client.call_tool(
             "update_transaction_splits",
             {"transaction_id": "txn-1", "split_data": []},
-        ))[0].text
+        )).content[0].text
     )
 
     assert "updateTransactionSplits" in result
@@ -114,6 +114,6 @@ async def test_update_splits_error(mcp_write_client, mock_monarch_client):
             "transaction_id": "txn-1",
             "split_data": [{"merchantName": "X", "amount": -50.0, "categoryId": "cat-1"}],
         },
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result

--- a/tests/test_transaction_tagging.py
+++ b/tests/test_transaction_tagging.py
@@ -12,7 +12,7 @@ async def test_apply_single_tag(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "set_transaction_tags", {"transaction_id": "txn-1", "tag_ids": ["tag-1"]}
-        ))[0].text
+        )).content[0].text
     )
 
     assert "setTransactionTags" in result
@@ -35,7 +35,7 @@ async def test_apply_multiple_tags(mcp_write_client, mock_monarch_client):
         (await mcp_write_client.call_tool(
             "set_transaction_tags",
             {"transaction_id": "txn-1", "tag_ids": ["tag-1", "tag-2"]},
-        ))[0].text
+        )).content[0].text
     )
 
     tags = result["setTransactionTags"]["transaction"]["tags"]
@@ -53,7 +53,7 @@ async def test_remove_all_tags(mcp_write_client, mock_monarch_client):
     result = json.loads(
         (await mcp_write_client.call_tool(
             "set_transaction_tags", {"transaction_id": "txn-1", "tag_ids": []}
-        ))[0].text
+        )).content[0].text
     )
 
     tags = result["setTransactionTags"]["transaction"]["tags"]
@@ -68,7 +68,7 @@ async def test_invalid_transaction_id(mcp_write_client, mock_monarch_client):
 
     result = (await mcp_write_client.call_tool(
         "set_transaction_tags", {"transaction_id": "bad-id", "tag_ids": ["tag-1"]}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
     assert "Transaction not found" in result
@@ -81,7 +81,7 @@ async def test_nonexistent_tag_id(mcp_write_client, mock_monarch_client):
 
     result = (await mcp_write_client.call_tool(
         "set_transaction_tags", {"transaction_id": "txn-1", "tag_ids": ["bad-tag"]}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
     assert "Tag not found" in result

--- a/tests/test_transaction_tagging.py
+++ b/tests/test_transaction_tagging.py
@@ -3,21 +3,23 @@
 
 import json
 
-from monarch_mcp_server.server import set_transaction_tags
 
-
-def test_apply_single_tag(mock_monarch_client):
+async def test_apply_single_tag(mcp_write_client, mock_monarch_client):
     mock_monarch_client.set_transaction_tags.return_value = {
         "setTransactionTags": {"transaction": {"tags": [{"id": "tag-1", "name": "Vacation"}]}}
     }
 
-    result = json.loads(set_transaction_tags(transaction_id="txn-1", tag_ids=["tag-1"]))
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "set_transaction_tags", {"transaction_id": "txn-1", "tag_ids": ["tag-1"]}
+        ))[0].text
+    )
 
     assert "setTransactionTags" in result
     mock_monarch_client.set_transaction_tags.assert_called_once_with("txn-1", ["tag-1"])
 
 
-def test_apply_multiple_tags(mock_monarch_client):
+async def test_apply_multiple_tags(mcp_write_client, mock_monarch_client):
     mock_monarch_client.set_transaction_tags.return_value = {
         "setTransactionTags": {
             "transaction": {
@@ -30,7 +32,10 @@ def test_apply_multiple_tags(mock_monarch_client):
     }
 
     result = json.loads(
-        set_transaction_tags(transaction_id="txn-1", tag_ids=["tag-1", "tag-2"])
+        (await mcp_write_client.call_tool(
+            "set_transaction_tags",
+            {"transaction_id": "txn-1", "tag_ids": ["tag-1", "tag-2"]},
+        ))[0].text
     )
 
     tags = result["setTransactionTags"]["transaction"]["tags"]
@@ -40,35 +45,43 @@ def test_apply_multiple_tags(mock_monarch_client):
     )
 
 
-def test_remove_all_tags(mock_monarch_client):
+async def test_remove_all_tags(mcp_write_client, mock_monarch_client):
     mock_monarch_client.set_transaction_tags.return_value = {
         "setTransactionTags": {"transaction": {"tags": []}}
     }
 
-    result = json.loads(set_transaction_tags(transaction_id="txn-1", tag_ids=[]))
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "set_transaction_tags", {"transaction_id": "txn-1", "tag_ids": []}
+        ))[0].text
+    )
 
     tags = result["setTransactionTags"]["transaction"]["tags"]
     assert tags == []
     mock_monarch_client.set_transaction_tags.assert_called_once_with("txn-1", [])
 
 
-def test_invalid_transaction_id(mock_monarch_client):
+async def test_invalid_transaction_id(mcp_write_client, mock_monarch_client):
     mock_monarch_client.set_transaction_tags.side_effect = Exception(
         "Transaction not found"
     )
 
-    result = set_transaction_tags(transaction_id="bad-id", tag_ids=["tag-1"])
+    result = (await mcp_write_client.call_tool(
+        "set_transaction_tags", {"transaction_id": "bad-id", "tag_ids": ["tag-1"]}
+    ))[0].text
 
     assert "Error" in result
     assert "Transaction not found" in result
 
 
-def test_nonexistent_tag_id(mock_monarch_client):
+async def test_nonexistent_tag_id(mcp_write_client, mock_monarch_client):
     mock_monarch_client.set_transaction_tags.side_effect = Exception(
         "Tag not found"
     )
 
-    result = set_transaction_tags(transaction_id="txn-1", tag_ids=["bad-tag"])
+    result = (await mcp_write_client.call_tool(
+        "set_transaction_tags", {"transaction_id": "txn-1", "tag_ids": ["bad-tag"]}
+    ))[0].text
 
     assert "Error" in result
     assert "Tag not found" in result

--- a/tests/test_transactions_read.py
+++ b/tests/test_transactions_read.py
@@ -44,7 +44,7 @@ async def test_basic_limit(mcp_client, mock_monarch_client):
     )
 
     result = json.loads(
-        (await mcp_client.call_tool("get_transactions", {"limit": 10}))[0].text
+        (await mcp_client.call_tool("get_transactions", {"limit": 10})).content[0].text
     )
 
     assert len(result) == 10
@@ -115,7 +115,7 @@ async def test_combined_account_and_date(mcp_client, mock_monarch_client):
 
 async def test_only_start_date_error(mcp_client):
     result = json.loads(
-        (await mcp_client.call_tool("get_transactions", {"start_date": "2025-01-01"}))[0].text
+        (await mcp_client.call_tool("get_transactions", {"start_date": "2025-01-01"})).content[0].text
     )
     assert "error" in result
 
@@ -127,7 +127,7 @@ async def test_only_start_date_error(mcp_client):
 
 async def test_only_end_date_error(mcp_client):
     result = json.loads(
-        (await mcp_client.call_tool("get_transactions", {"end_date": "2025-01-31"}))[0].text
+        (await mcp_client.call_tool("get_transactions", {"end_date": "2025-01-31"})).content[0].text
     )
     assert "error" in result
 
@@ -143,10 +143,10 @@ async def test_pagination_no_overlap(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.side_effect = [_wrap(page1), _wrap(page2)]
 
     r1 = json.loads(
-        (await mcp_client.call_tool("get_transactions", {"limit": 5, "offset": 0}))[0].text
+        (await mcp_client.call_tool("get_transactions", {"limit": 5, "offset": 0})).content[0].text
     )
     r2 = json.loads(
-        (await mcp_client.call_tool("get_transactions", {"limit": 5, "offset": 5}))[0].text
+        (await mcp_client.call_tool("get_transactions", {"limit": 5, "offset": 5})).content[0].text
     )
 
     ids1 = {t["id"] for t in r1}
@@ -163,7 +163,7 @@ async def test_large_offset_empty(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([])
 
     result = json.loads(
-        (await mcp_client.call_tool("get_transactions", {"limit": 10, "offset": 99999}))[0].text
+        (await mcp_client.call_tool("get_transactions", {"limit": 10, "offset": 99999})).content[0].text
     )
 
     assert result == []
@@ -178,7 +178,7 @@ async def test_limit_zero(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([])
 
     result = json.loads(
-        (await mcp_client.call_tool("get_transactions", {"limit": 0}))[0].text
+        (await mcp_client.call_tool("get_transactions", {"limit": 0})).content[0].text
     )
 
     assert result == []
@@ -194,7 +194,7 @@ async def test_negative_limit(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([])
 
     result = json.loads(
-        (await mcp_client.call_tool("get_transactions", {"limit": -1}))[0].text
+        (await mcp_client.call_tool("get_transactions", {"limit": -1})).content[0].text
     )
 
     assert isinstance(result, list)
@@ -210,7 +210,7 @@ async def test_negative_offset(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([])
 
     result = json.loads(
-        (await mcp_client.call_tool("get_transactions", {"limit": 10, "offset": -1}))[0].text
+        (await mcp_client.call_tool("get_transactions", {"limit": 10, "offset": -1})).content[0].text
     )
 
     assert isinstance(result, list)
@@ -228,7 +228,7 @@ async def test_very_large_limit(mcp_client, mock_monarch_client):
     )
 
     result = json.loads(
-        (await mcp_client.call_tool("get_transactions", {"limit": 999999}))[0].text
+        (await mcp_client.call_tool("get_transactions", {"limit": 999999})).content[0].text
     )
 
     assert len(result) == 3
@@ -247,7 +247,7 @@ async def test_invalid_date_format(mcp_client, mock_monarch_client):
 
     result = (await mcp_client.call_tool(
         "get_transactions", {"start_date": "not-a-date", "end_date": "also-not"}
-    ))[0].text
+    )).content[0].text
 
     assert "Error" in result
     assert "Invalid date format" in result
@@ -264,7 +264,7 @@ async def test_future_dates_empty(mcp_client, mock_monarch_client):
     result = json.loads(
         (await mcp_client.call_tool(
             "get_transactions", {"start_date": "2099-01-01", "end_date": "2099-12-31"}
-        ))[0].text
+        )).content[0].text
     )
 
     assert result == []
@@ -328,7 +328,7 @@ async def test_account_id_and_account_ids_conflict(mcp_client):
     result = json.loads(
         (await mcp_client.call_tool(
             "get_transactions", {"account_id": "acc-1", "account_ids": ["acc-2"]}
-        ))[0].text
+        )).content[0].text
     )
     assert "error" in result
 

--- a/tests/test_transactions_read.py
+++ b/tests/test_transactions_read.py
@@ -3,7 +3,6 @@
 
 import json
 
-from monarch_mcp_server.server import get_transactions
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -39,12 +38,14 @@ def _wrap(txns):
 # ---------------------------------------------------------------------------
 
 
-def test_basic_limit(mock_monarch_client):
+async def test_basic_limit(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap(
         [_make_txn(i) for i in range(10)]
     )
 
-    result = json.loads(get_transactions(limit=10))
+    result = json.loads(
+        (await mcp_client.call_tool("get_transactions", {"limit": 10}))[0].text
+    )
 
     assert len(result) == 10
     mock_monarch_client.get_transactions.assert_called_once_with(limit=10, offset=0)
@@ -55,10 +56,12 @@ def test_basic_limit(mock_monarch_client):
 # ---------------------------------------------------------------------------
 
 
-def test_date_range(mock_monarch_client):
+async def test_date_range(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
 
-    get_transactions(start_date="2025-01-01", end_date="2025-01-31")
+    await mcp_client.call_tool(
+        "get_transactions", {"start_date": "2025-01-01", "end_date": "2025-01-31"}
+    )
 
     mock_monarch_client.get_transactions.assert_called_once_with(
         limit=100,
@@ -73,10 +76,10 @@ def test_date_range(mock_monarch_client):
 # ---------------------------------------------------------------------------
 
 
-def test_account_id_filter(mock_monarch_client):
+async def test_account_id_filter(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
 
-    get_transactions(account_id="acc-1")
+    await mcp_client.call_tool("get_transactions", {"account_id": "acc-1"})
 
     mock_monarch_client.get_transactions.assert_called_once_with(
         limit=100, offset=0, account_ids=["acc-1"]
@@ -88,11 +91,12 @@ def test_account_id_filter(mock_monarch_client):
 # ---------------------------------------------------------------------------
 
 
-def test_combined_account_and_date(mock_monarch_client):
+async def test_combined_account_and_date(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
 
-    get_transactions(
-        start_date="2025-01-01", end_date="2025-01-31", account_id="acc-1"
+    await mcp_client.call_tool(
+        "get_transactions",
+        {"start_date": "2025-01-01", "end_date": "2025-01-31", "account_id": "acc-1"},
     )
 
     mock_monarch_client.get_transactions.assert_called_once_with(
@@ -109,8 +113,10 @@ def test_combined_account_and_date(mock_monarch_client):
 # ---------------------------------------------------------------------------
 
 
-def test_only_start_date_error():
-    result = json.loads(get_transactions(start_date="2025-01-01"))
+async def test_only_start_date_error(mcp_client):
+    result = json.loads(
+        (await mcp_client.call_tool("get_transactions", {"start_date": "2025-01-01"}))[0].text
+    )
     assert "error" in result
 
 
@@ -119,8 +125,10 @@ def test_only_start_date_error():
 # ---------------------------------------------------------------------------
 
 
-def test_only_end_date_error():
-    result = json.loads(get_transactions(end_date="2025-01-31"))
+async def test_only_end_date_error(mcp_client):
+    result = json.loads(
+        (await mcp_client.call_tool("get_transactions", {"end_date": "2025-01-31"}))[0].text
+    )
     assert "error" in result
 
 
@@ -129,13 +137,17 @@ def test_only_end_date_error():
 # ---------------------------------------------------------------------------
 
 
-def test_pagination_no_overlap(mock_monarch_client):
+async def test_pagination_no_overlap(mcp_client, mock_monarch_client):
     page1 = [_make_txn(i) for i in range(5)]
     page2 = [_make_txn(i + 5) for i in range(5)]
     mock_monarch_client.get_transactions.side_effect = [_wrap(page1), _wrap(page2)]
 
-    r1 = json.loads(get_transactions(limit=5, offset=0))
-    r2 = json.loads(get_transactions(limit=5, offset=5))
+    r1 = json.loads(
+        (await mcp_client.call_tool("get_transactions", {"limit": 5, "offset": 0}))[0].text
+    )
+    r2 = json.loads(
+        (await mcp_client.call_tool("get_transactions", {"limit": 5, "offset": 5}))[0].text
+    )
 
     ids1 = {t["id"] for t in r1}
     ids2 = {t["id"] for t in r2}
@@ -147,10 +159,12 @@ def test_pagination_no_overlap(mock_monarch_client):
 # ---------------------------------------------------------------------------
 
 
-def test_large_offset_empty(mock_monarch_client):
+async def test_large_offset_empty(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([])
 
-    result = json.loads(get_transactions(limit=10, offset=99999))
+    result = json.loads(
+        (await mcp_client.call_tool("get_transactions", {"limit": 10, "offset": 99999}))[0].text
+    )
 
     assert result == []
 
@@ -160,10 +174,12 @@ def test_large_offset_empty(mock_monarch_client):
 # ---------------------------------------------------------------------------
 
 
-def test_limit_zero(mock_monarch_client):
+async def test_limit_zero(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([])
 
-    result = json.loads(get_transactions(limit=0))
+    result = json.loads(
+        (await mcp_client.call_tool("get_transactions", {"limit": 0}))[0].text
+    )
 
     assert result == []
     mock_monarch_client.get_transactions.assert_called_once_with(limit=0, offset=0)
@@ -174,10 +190,12 @@ def test_limit_zero(mock_monarch_client):
 # ---------------------------------------------------------------------------
 
 
-def test_negative_limit(mock_monarch_client):
+async def test_negative_limit(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([])
 
-    result = json.loads(get_transactions(limit=-1))
+    result = json.loads(
+        (await mcp_client.call_tool("get_transactions", {"limit": -1}))[0].text
+    )
 
     assert isinstance(result, list)
     mock_monarch_client.get_transactions.assert_called_once_with(limit=-1, offset=0)
@@ -188,10 +206,12 @@ def test_negative_limit(mock_monarch_client):
 # ---------------------------------------------------------------------------
 
 
-def test_negative_offset(mock_monarch_client):
+async def test_negative_offset(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([])
 
-    result = json.loads(get_transactions(limit=10, offset=-1))
+    result = json.loads(
+        (await mcp_client.call_tool("get_transactions", {"limit": 10, "offset": -1}))[0].text
+    )
 
     assert isinstance(result, list)
     mock_monarch_client.get_transactions.assert_called_once_with(limit=10, offset=-1)
@@ -202,12 +222,14 @@ def test_negative_offset(mock_monarch_client):
 # ---------------------------------------------------------------------------
 
 
-def test_very_large_limit(mock_monarch_client):
+async def test_very_large_limit(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap(
         [_make_txn(i) for i in range(3)]
     )
 
-    result = json.loads(get_transactions(limit=999999))
+    result = json.loads(
+        (await mcp_client.call_tool("get_transactions", {"limit": 999999}))[0].text
+    )
 
     assert len(result) == 3
     mock_monarch_client.get_transactions.assert_called_once_with(
@@ -220,10 +242,12 @@ def test_very_large_limit(mock_monarch_client):
 # ---------------------------------------------------------------------------
 
 
-def test_invalid_date_format(mock_monarch_client):
+async def test_invalid_date_format(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.side_effect = Exception("Invalid date format")
 
-    result = get_transactions(start_date="not-a-date", end_date="also-not")
+    result = (await mcp_client.call_tool(
+        "get_transactions", {"start_date": "not-a-date", "end_date": "also-not"}
+    ))[0].text
 
     assert "Error" in result
     assert "Invalid date format" in result
@@ -234,11 +258,13 @@ def test_invalid_date_format(mock_monarch_client):
 # ---------------------------------------------------------------------------
 
 
-def test_future_dates_empty(mock_monarch_client):
+async def test_future_dates_empty(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([])
 
     result = json.loads(
-        get_transactions(start_date="2099-01-01", end_date="2099-12-31")
+        (await mcp_client.call_tool(
+            "get_transactions", {"start_date": "2099-01-01", "end_date": "2099-12-31"}
+        ))[0].text
     )
 
     assert result == []
@@ -249,10 +275,10 @@ def test_future_dates_empty(mock_monarch_client):
 # ---------------------------------------------------------------------------
 
 
-def test_search_filter(mock_monarch_client):
+async def test_search_filter(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
 
-    get_transactions(search="coffee")
+    await mcp_client.call_tool("get_transactions", {"search": "coffee"})
 
     mock_monarch_client.get_transactions.assert_called_once_with(
         limit=100, offset=0, search="coffee"
@@ -264,10 +290,12 @@ def test_search_filter(mock_monarch_client):
 # ---------------------------------------------------------------------------
 
 
-def test_category_ids_filter(mock_monarch_client):
+async def test_category_ids_filter(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
 
-    get_transactions(category_ids=["cat-1", "cat-2"])
+    await mcp_client.call_tool(
+        "get_transactions", {"category_ids": ["cat-1", "cat-2"]}
+    )
 
     mock_monarch_client.get_transactions.assert_called_once_with(
         limit=100, offset=0, category_ids=["cat-1", "cat-2"]
@@ -279,10 +307,12 @@ def test_category_ids_filter(mock_monarch_client):
 # ---------------------------------------------------------------------------
 
 
-def test_account_ids_filter(mock_monarch_client):
+async def test_account_ids_filter(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
 
-    get_transactions(account_ids=["acc-1", "acc-2"])
+    await mcp_client.call_tool(
+        "get_transactions", {"account_ids": ["acc-1", "acc-2"]}
+    )
 
     mock_monarch_client.get_transactions.assert_called_once_with(
         limit=100, offset=0, account_ids=["acc-1", "acc-2"]
@@ -294,9 +324,11 @@ def test_account_ids_filter(mock_monarch_client):
 # ---------------------------------------------------------------------------
 
 
-def test_account_id_and_account_ids_conflict():
+async def test_account_id_and_account_ids_conflict(mcp_client):
     result = json.loads(
-        get_transactions(account_id="acc-1", account_ids=["acc-2"])
+        (await mcp_client.call_tool(
+            "get_transactions", {"account_id": "acc-1", "account_ids": ["acc-2"]}
+        ))[0].text
     )
     assert "error" in result
 
@@ -306,10 +338,10 @@ def test_account_id_and_account_ids_conflict():
 # ---------------------------------------------------------------------------
 
 
-def test_tag_ids_filter(mock_monarch_client):
+async def test_tag_ids_filter(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
 
-    get_transactions(tag_ids=["tag-1"])
+    await mcp_client.call_tool("get_transactions", {"tag_ids": ["tag-1"]})
 
     mock_monarch_client.get_transactions.assert_called_once_with(
         limit=100, offset=0, tag_ids=["tag-1"]
@@ -321,10 +353,12 @@ def test_tag_ids_filter(mock_monarch_client):
 # ---------------------------------------------------------------------------
 
 
-def test_bool_filters(mock_monarch_client):
+async def test_bool_filters(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
 
-    get_transactions(has_notes=True, is_recurring=False)
+    await mcp_client.call_tool(
+        "get_transactions", {"has_notes": True, "is_recurring": False}
+    )
 
     mock_monarch_client.get_transactions.assert_called_once_with(
         limit=100, offset=0, has_notes=True, is_recurring=False
@@ -336,10 +370,12 @@ def test_bool_filters(mock_monarch_client):
 # ---------------------------------------------------------------------------
 
 
-def test_hidden_from_reports_filter(mock_monarch_client):
+async def test_hidden_from_reports_filter(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
 
-    get_transactions(hidden_from_reports=True)
+    await mcp_client.call_tool(
+        "get_transactions", {"hidden_from_reports": True}
+    )
 
     mock_monarch_client.get_transactions.assert_called_once_with(
         limit=100, offset=0, hidden_from_reports=True
@@ -351,15 +387,18 @@ def test_hidden_from_reports_filter(mock_monarch_client):
 # ---------------------------------------------------------------------------
 
 
-def test_combined_search_and_filters(mock_monarch_client):
+async def test_combined_search_and_filters(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
 
-    get_transactions(
-        search="grocery",
-        category_ids=["cat-1"],
-        start_date="2025-01-01",
-        end_date="2025-01-31",
-        is_split=False,
+    await mcp_client.call_tool(
+        "get_transactions",
+        {
+            "search": "grocery",
+            "category_ids": ["cat-1"],
+            "start_date": "2025-01-01",
+            "end_date": "2025-01-31",
+            "is_split": False,
+        },
     )
 
     mock_monarch_client.get_transactions.assert_called_once_with(

--- a/tests/test_write_mode.py
+++ b/tests/test_write_mode.py
@@ -1,0 +1,48 @@
+"""Tests for the --enable-write CLI flag and _WRITE_ENABLED module flag."""
+
+import importlib
+
+import monarch_mcp_server.server as server_module
+
+
+def _resolve_flag(monkeypatch, argv):
+    """Re-parse the flag with a custom sys.argv and return the resolved bool."""
+    monkeypatch.setattr("sys.argv", argv)
+    parsed, _ = server_module._arg_parser.parse_known_args()  # pylint: disable=protected-access
+    return parsed.enable_write.lower() in ("true", "1")
+
+
+class TestEnableWriteFlag:
+    """Verify every accepted form of --enable-write."""
+
+    def test_default_no_flag(self, monkeypatch):
+        """No flag → False."""
+        assert _resolve_flag(monkeypatch, ["server.py"]) is False
+
+    def test_bare_flag(self, monkeypatch):
+        """--enable-write (no value) → True."""
+        assert _resolve_flag(monkeypatch, ["server.py", "--enable-write"]) is True
+
+    def test_equals_true_lower(self, monkeypatch):
+        """--enable-write=true → True."""
+        assert _resolve_flag(monkeypatch, ["server.py", "--enable-write=true"]) is True
+
+    def test_equals_true_upper(self, monkeypatch):
+        """--enable-write=True (case-insensitive) → True."""
+        assert _resolve_flag(monkeypatch, ["server.py", "--enable-write=True"]) is True
+
+    def test_equals_one(self, monkeypatch):
+        """--enable-write=1 → True."""
+        assert _resolve_flag(monkeypatch, ["server.py", "--enable-write=1"]) is True
+
+    def test_equals_false(self, monkeypatch):
+        """--enable-write=false → False."""
+        assert _resolve_flag(monkeypatch, ["server.py", "--enable-write=false"]) is False
+
+    def test_equals_zero(self, monkeypatch):
+        """--enable-write=0 → False."""
+        assert _resolve_flag(monkeypatch, ["server.py", "--enable-write=0"]) is False
+
+    def test_module_level_default(self):
+        """Module-level _WRITE_ENABLED is False in test env (no CLI flag)."""
+        assert server_module._WRITE_ENABLED is False  # pylint: disable=protected-access


### PR DESCRIPTION
## Summary
- **Read-only mode by default**: All 13 write tools (create/update/delete for transactions, tags, categories, accounts, budgets, splits) are disabled unless `--enable-write` is passed. This prevents accidental mutations to financial data.
- **Migrate from `mcp` SDK to `fastmcp` package**: Uses `fastmcp.FastMCP` instead of `mcp.server.fastmcp.FastMCP`, aligning with the modern package.
- **Branching policy**: Adds rule to CLAUDE.md to prevent direct commits to `main`.
- **Test skill updated**: Supports both read-only (26 tools, 63 tests) and write-enabled (39 tools, 127 tests) modes.

## Test plan
- [ ] `py -m pytest tests/` — all 237 tests pass
- [ ] `py -m pylint src/monarch_mcp_server/` — 10.00/10
- [ ] Verify server starts in read-only mode by default (write tools not listed)
- [ ] Verify `--enable-write` flag exposes all 39 tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)