### PR TITLE
Fix date serialization and mcpb bundle issues

### DIFF
--- a/.mcpbignore
+++ b/.mcpbignore
@@ -4,6 +4,7 @@
 CLAUDE.md
 tests/
 venv/
+.venv/
 *.egg-info/
 __pycache__/
 .mypy_cache/

--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,8 @@
       "command": "uv",
       "args": [
         "run",
+        "--python",
+        "3.12",
         "--directory",
         "${__dirname}",
         "fastmcp",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
 ]
-requires-python = ">=3.12"
+requires-python = ">=3.12,<3.14"
 dependencies = [
     "fastmcp>=2.12.0",
     "monarchmoneycommunity~=1.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 requires-python = ">=3.12,<3.14"
 dependencies = [
-    "fastmcp>=2.12.0",
+    "fastmcp>=2.12.0,<3",
     "monarchmoneycommunity~=1.3.0",
     "keyring>=24.0.0",
     "python-dotenv>=1.0.0",

--- a/src/monarch_mcp/server.py
+++ b/src/monarch_mcp/server.py
@@ -1214,11 +1214,10 @@ def get_aggregate_snapshots(
     async def _get_aggregate_snapshots():
         client = await get_monarch_client()
         kwargs = {}
-        # monarchmoney library requires date objects (not strings) for this method
         if start_date is not None:
-            kwargs["start_date"] = datetime.strptime(start_date, "%Y-%m-%d").date()
+            kwargs["start_date"] = start_date
         if end_date is not None:
-            kwargs["end_date"] = datetime.strptime(end_date, "%Y-%m-%d").date()
+            kwargs["end_date"] = end_date
         if account_type is not None:
             kwargs["account_type"] = account_type
         return await client.get_aggregate_snapshots(**kwargs)

--- a/tests/test_account_management.py
+++ b/tests/test_account_management.py
@@ -313,9 +313,8 @@ async def test_aggregate_snapshots_with_dates(mcp_client, mock_monarch_client):
         {"start_date": "2025-01-01", "end_date": "2025-12-31"},
     )
 
-    from datetime import date
     mock_monarch_client.get_aggregate_snapshots.assert_called_once_with(
-        start_date=date(2025, 1, 1), end_date=date(2025, 12, 31)
+        start_date="2025-01-01", end_date="2025-12-31"
     )
 
 


### PR DESCRIPTION
## Summary
- **Fix `get_aggregate_snapshots` date serialization bug**: Pass date strings directly to the monarchmoney library instead of converting to Python `date` objects, which caused `"Object of type date is not JSON serializable"` errors.
- **Fix mcpb bundle failing on Python 3.14**: Exclude `.venv/` from the bundle, pin `--python 3.12` in manifest args, and constrain `requires-python` to `<3.14` since `pydantic-core` can't build on 3.14.

## Test plan
- [x] `get_aggregate_snapshots` verified working against live Monarch API after fix
- [x] mcpb bundle tested and confirmed working on target machine
- [x] All 238 unit tests pass
- [x] Pylint 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)