### PR TITLE
Fix gh release view in publish-rc validation

### DIFF
--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -19,12 +19,16 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Validate RC tag
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           TAG="${{ inputs.tag }}"
           if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+rc[0-9]+$ ]]; then


### PR DESCRIPTION
## Summary
- Add `GH_TOKEN` env var and `contents: read` permission to the `validate` job in `publish-rc.yml`
- The `gh release view` command needs an explicit token to query releases in `workflow_dispatch` workflows

## Test plan
- [ ] Run `gh workflow run publish-rc.yml -f tag=v0.1.3rc2 -f target=pypi` and confirm validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)