### PR TITLE
Add create_transaction_rule tool and slim get_transaction_categories response

### DIFF
--- a/.claude/skills/test-monarch-mcp/SKILL.md
+++ b/.claude/skills/test-monarch-mcp/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: test-monarch-mcp
-description: Systematically test Monarch Money MCP tools in read-only mode (26 tools, 65 tests) or write-enabled mode (all 39 tools, 129 tests). Account-agnostic (discovers IDs at runtime) and self-cleaning (deletes everything it creates in write mode).
+description: Systematically test Monarch Money MCP tools in read-only mode (26 tools, 65 tests) or write-enabled mode (all 40 tools, 136 tests). Account-agnostic (discovers IDs at runtime) and self-cleaning (deletes everything it creates in write mode).
 user_invocable: true
 ---
 
 # Test Monarch MCP Skill
 
 You are executing a comprehensive test suite for the Monarch Money MCP server.
-Run tests across 12 phases, track results, and clean up after yourself.
+Run tests across 13 phases, track results, and clean up after yourself.
 
 ---
 
@@ -16,7 +16,7 @@ Run tests across 12 phases, track results, and clean up after yourself.
 This test suite supports two modes, auto-detected at startup:
 
 - **Read-only mode** (default): Tests 26 read-only tools (65 tests). Write-dependent tests are skipped. No data is created, modified, or deleted.
-- **Write-enabled mode** (`--enable-write`): Tests all 39 tools (129 tests). Creates, modifies, and deletes data on your live Monarch account. Self-cleaning.
+- **Write-enabled mode** (`--enable-write`): Tests all 40 tools (136 tests). Creates, modifies, and deletes data on your live Monarch account. Self-cleaning.
 
 ---
 
@@ -67,7 +67,7 @@ The state file is `mcp-test-state.json` in the project root.
   },
   "results": {},
   "summary": {
-    "total": 129,
+    "total": 136,
     "passed": 0,
     "failed": 0,
     "skipped": 0
@@ -76,7 +76,7 @@ The state file is `mcp-test-state.json` in the project root.
 ```
 
 In **read-only mode**, `summary.total` is `65` and `original_values` is omitted (no mutations will happen).
-In **write-enabled mode**, `summary.total` is `129`.
+In **write-enabled mode**, `summary.total` is `136`.
 
 ### Update Cadence
 
@@ -114,9 +114,9 @@ Based on the detected mode, display the appropriate message and **STOP and wait 
 
 **Server is running in read-only mode (26 tools).**
 
-I'll run 63 read-only tests and skip 64 write tests. No data will be created, modified, or deleted on your Monarch account.
+I'll run 65 read-only tests and skip 71 write tests. No data will be created, modified, or deleted on your Monarch account.
 
-To test all 127 tools, disable `monarch-money-read-only` and enable `monarch-money` in `.mcp.json`, then restart.
+To test all 136 tests, disable `monarch-money-read-only` and enable `monarch-money` in `.mcp.json`, then restart.
 
 **Proceed with read-only tests?**
 
@@ -126,9 +126,9 @@ To test all 127 tools, disable `monarch-money-read-only` and enable `monarch-mon
 
 ---
 
-**WARNING: Server is running in read-write mode (all 39 tools).**
+**WARNING: Server is running in read-write mode (all 40 tools).**
 
-I'll run all 129 tests. This will **create, modify, and delete** data on your **live Monarch Money account**:
+I'll run all 136 tests. This will **create, modify, and delete** data on your **live Monarch Money account**:
 
 - It **creates and deletes** transactions, tags, categories, and accounts.
 - It **temporarily modifies** an existing transaction (then reverts it).
@@ -315,6 +315,20 @@ After completing all tests, update state file: `last_completed_phase: 12`, add r
 
 ---
 
+## Phase 13 — Transaction Rules (7 tests)
+
+Load and follow: `references/transaction-rules.md`
+
+**Read-only mode:** Skip entire phase (0 tests). All tests require write tools.
+
+Tests `create_transaction_rule` — happy paths, operator variants, backfill flag, and input validation.
+
+> ⚠️ Rules cannot be deleted via the API. Test rules will persist in the account and must be removed manually via the Monarch UI if desired.
+
+After completing all tests, update state file: `last_completed_phase: 13`, add results.
+
+---
+
 ## Cleanup Phase
 
 ### Read-only mode
@@ -415,9 +429,10 @@ After cleanup (or after skipping cleanup in read-only mode), print a final summa
 ║ Phase 10 — Read-Only Tools:   9/9  PASS          ║
 ║ Phase 11 — Account Mgmt:      6/6  PASS          ║
 ║ Phase 12 — Analytics:         5/5  PASS          ║
+║ Phase 13 — Rules:             SKIPPED (write)    ║
 ╠══════════════════════════════════════════════════╣
 ║ TOTAL: 65 passed, 0 failed, 0 skipped           ║
-║ Write tests skipped: 64 (server in read-only)    ║
+║ Write tests skipped: 71 (server in read-only)    ║
 ╚══════════════════════════════════════════════════╝
 ```
 
@@ -439,8 +454,9 @@ After cleanup (or after skipping cleanup in read-only mode), print a final summa
 ║ Phase 10 — Read-Only Tools:   9/9  PASS          ║
 ║ Phase 11 — Account Mgmt:      10/10 PASS         ║
 ║ Phase 12 — Analytics:         5/5  PASS          ║
+║ Phase 13 — Transaction Rules: 7/7  PASS          ║
 ╠══════════════════════════════════════════════════╣
-║ TOTAL: 129 passed, 0 failed, 0 skipped          ║
+║ TOTAL: 136 passed, 0 failed, 0 skipped          ║
 ╚══════════════════════════════════════════════════╝
 ```
 

--- a/.claude/skills/test-monarch-mcp/references/categories.md
+++ b/.claude/skills/test-monarch-mcp/references/categories.md
@@ -4,7 +4,7 @@
 
 ## 8.1 — get_transaction_categories: returns categories
 Call `get_transaction_categories()`.
-**Expected:** JSON with a `categories` key containing a non-empty list. Each category has `id`, `name`, and `group`.
+**Expected:** A JSON array (not wrapped in a key) with at least one item. Each item has `id`, `name`, `is_disabled`, `group_name`, and `group_type`.
 
 ## 8.2 — get_transaction_category_groups: returns groups
 Call `get_transaction_category_groups()`.

--- a/.claude/skills/test-monarch-mcp/references/transaction-rules.md
+++ b/.claude/skills/test-monarch-mcp/references/transaction-rules.md
@@ -1,0 +1,37 @@
+# Phase 13 — Transaction Rules (7 tests)
+
+> **Read-only mode:** Skip entire phase (0 tests). All tests require write tools.
+
+> ⚠️ **No cleanup possible**: Monarch has no delete-rule API. Rules created here persist in the
+> account. All test rules use merchant/statement values prefixed with `MCP-Test-` for easy
+> manual identification and deletion via the Monarch UI.
+
+Use `{valid_category_id}` from discovery for all `set_category_id` arguments.
+
+## 13.1 — create_transaction_rule: merchant name match (contains)
+Call `create_transaction_rule(set_category_id={valid_category_id}, merchant_name_value="MCP-Test-Merchant")`.
+**Expected:** JSON with `created: true`.
+
+## 13.2 — create_transaction_rule: original statement match
+Call `create_transaction_rule(set_category_id={valid_category_id}, original_statement_value="MCP-Test-Statement")`.
+**Expected:** JSON with `created: true`.
+
+## 13.3 — create_transaction_rule: both conditions
+Call `create_transaction_rule(set_category_id={valid_category_id}, merchant_name_value="MCP-Test-Both", original_statement_value="MCP-Test-Both-Stmt")`.
+**Expected:** JSON with `created: true`.
+
+## 13.4 — create_transaction_rule: exact match operator
+Call `create_transaction_rule(set_category_id={valid_category_id}, merchant_name_value="MCP-Test-Exact", merchant_name_operator="eq")`.
+**Expected:** JSON with `created: true`.
+
+## 13.5 — create_transaction_rule: apply_to_existing_transactions
+Call `create_transaction_rule(set_category_id={valid_category_id}, merchant_name_value="MCP-Test-Backfill", apply_to_existing_transactions=True)`.
+**Expected:** JSON with `created: true`.
+
+## 13.6 — create_transaction_rule: validation — neither condition provided
+Call `create_transaction_rule(set_category_id={valid_category_id})`.
+**Expected:** JSON with an `error` key indicating at least one of `merchant_name_value` or `original_statement_value` is required.
+
+## 13.7 — create_transaction_rule: validation — invalid operator
+Call `create_transaction_rule(set_category_id={valid_category_id}, merchant_name_value="MCP-Test-Op", merchant_name_operator="regex")`.
+**Expected:** JSON with an `error` key indicating `merchant_name_operator` must be `contains` or `eq`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Model Context Protocol (MCP) server for integrating with the Monarch Money per
 
 - **Secure by design** — browser-based login, token stored in OS keychain (never in config files or env vars)
 - **Safe by default** — read-only mode prevents accidental changes; write tools require explicit opt-in
-- **Comprehensive** — 37 tools covering accounts, transactions, splits, budgets, cashflow, tags, categories, and credit history
+- **Comprehensive** — 38 tools covering accounts, transactions, splits, budgets, cashflow, tags, categories, rules, and credit history
 - **Easy to install** — Claude Desktop extension (`.mcpb`), `uvx`, or `pip`
 
 **Two operating modes:**
@@ -18,7 +18,7 @@ The server starts in **read-only mode** by default. Write tools are hidden and b
 |---|---|---|
 | **View** accounts, transactions, budgets | Yes | Yes |
 | **Analyze** cashflow, spending, net worth | Yes | Yes |
-| **Create** transactions, tags, categories | No | Yes |
+| **Create** transactions, tags, categories, rules | No | Yes |
 | **Update** accounts, budgets, splits | No | Yes |
 | **Delete** transactions, tags, accounts | No | Yes |
 
@@ -201,6 +201,8 @@ Create a tag called "Business Expenses" in red
 | `get_transaction_category_groups` | Get category groups | read |
 | `create_transaction_category` | Create a category | write |
 | `delete_transaction_category` | Delete a category | write |
+| **Rules** | | |
+| `create_transaction_rule` | Create an auto-categorization rule | write |
 | **Budgets & Cashflow** | | |
 | `get_budgets` | Get budget information | read |
 | `get_cashflow` | Get cashflow analysis | read |

--- a/src/monarch_mcp/server.py
+++ b/src/monarch_mcp/server.py
@@ -248,6 +248,7 @@ def get_transactions(  # pylint: disable=too-many-arguments,too-many-positional-
     is_split: Optional[bool] = None,
     is_recurring: Optional[bool] = None,
     synced_from_institution: Optional[bool] = None,
+    needs_review: Optional[bool] = None,
 ) -> str:
     """
     Get transactions from Monarch Money.
@@ -268,6 +269,7 @@ def get_transactions(  # pylint: disable=too-many-arguments,too-many-positional-
         is_split: Filter split/unsplit transactions
         is_recurring: Filter recurring/non-recurring transactions
         synced_from_institution: Filter synced/manual transactions
+        needs_review: Filter transactions that need review
     """
     if bool(start_date) != bool(end_date):
         return json.dumps(
@@ -311,6 +313,8 @@ def get_transactions(  # pylint: disable=too-many-arguments,too-many-positional-
             filters["is_recurring"] = is_recurring
         if synced_from_institution is not None:
             filters["synced_from_institution"] = synced_from_institution
+        if needs_review is not None:
+            filters["needs_review"] = needs_review
 
         return await client.get_transactions(limit=limit, offset=offset, **filters)
 
@@ -688,6 +692,106 @@ def set_transaction_tags(transaction_id: str, tag_ids: List[str]) -> str:
     return json.dumps(result, indent=2, default=str)
 
 
+@mcp.tool(enabled=_WRITE_ENABLED)
+@_handle_mcp_errors("creating transaction rule")
+def create_transaction_rule(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    set_category_id: str,
+    merchant_name_value: Optional[str] = None,
+    merchant_name_operator: str = "contains",
+    original_statement_value: Optional[str] = None,
+    original_statement_operator: str = "contains",
+    account_ids: Optional[List[str]] = None,
+    apply_to_existing_transactions: bool = False,
+) -> str:
+    """
+    Create a Monarch Money transaction rule that automatically categorizes transactions.
+
+    At least one of merchant_name_value or original_statement_value must be provided.
+
+    Args:
+        set_category_id: Category ID to assign when the rule matches (required)
+        merchant_name_value: Merchant name to match (e.g. "Amazon", "Whole Foods")
+        merchant_name_operator: How to match the merchant name — "contains" (default) or "eq"
+        original_statement_value: Raw statement description to match
+        original_statement_operator: How to match the statement text — "contains" (default) or "eq"
+        account_ids: Restrict rule to specific account IDs (null = all accounts)
+        apply_to_existing_transactions: Also re-categorize past transactions that match
+    """
+    if not merchant_name_value and not original_statement_value:
+        return json.dumps(
+            {"error": "At least one of merchant_name_value or "
+                      "original_statement_value is required"},
+            indent=2,
+        )
+
+    valid_operators = {"contains", "eq"}
+    if merchant_name_operator not in valid_operators:
+        return json.dumps(
+            {"error": f"merchant_name_operator must be one of: {sorted(valid_operators)}"},
+            indent=2,
+        )
+    if original_statement_operator not in valid_operators:
+        return json.dumps(
+            {"error": f"original_statement_operator must be one of: {sorted(valid_operators)}"},
+            indent=2,
+        )
+
+    input_data: Dict[str, Any] = {
+        "setCategoryAction": set_category_id,
+        "applyToExistingTransactions": apply_to_existing_transactions,
+    }
+
+    if merchant_name_value:
+        input_data["merchantNameCriteria"] = [
+            {"operator": merchant_name_operator, "value": merchant_name_value}
+        ]
+
+    if original_statement_value:
+        input_data["originalStatementCriteria"] = [
+            {"operator": original_statement_operator, "value": original_statement_value}
+        ]
+
+    if account_ids:
+        input_data["accountIds"] = account_ids
+
+    async def _create_transaction_rule():
+        client = await _get_monarch_client()
+        mutation = gql(
+            """
+            mutation Common_CreateTransactionRuleMutationV2($input: CreateTransactionRuleInput!) {
+                createTransactionRuleV2(input: $input) {
+                    errors {
+                        message
+                    }
+                }
+            }
+            """
+        )
+        variables = {"input": input_data}
+        return await client.gql_call(
+            operation="Common_CreateTransactionRuleMutationV2",
+            graphql_query=mutation,
+            variables=variables,
+        )
+
+    result = run_with_auth_recovery(_create_transaction_rule())
+
+    # Surface any API-level errors from the mutation payload.
+    # errors can be None (success), a list, or a bare dict — normalise to list.
+    rule_result = result.get("createTransactionRuleV2", {}) if isinstance(result, dict) else {}
+    raw_errors = rule_result.get("errors")
+    if isinstance(raw_errors, dict):
+        raw_errors = [raw_errors]
+    errors = raw_errors or []
+    if errors:
+        return json.dumps(
+            {"error": errors[0].get("message", "Unknown error"), "errors": errors},
+            indent=2,
+        )
+
+    return json.dumps({"created": True, "input": input_data}, indent=2)
+
+
 # ── Phase 2: Read-only tools ──────────────────────────────────────────
 
 
@@ -702,7 +806,17 @@ def get_transaction_categories() -> str:
 
     categories = run_with_auth_recovery(_get_transaction_categories())
 
-    return json.dumps(categories, indent=2, default=str)
+    slim = [
+        {
+            "id": c.get("id"),
+            "name": c.get("name"),
+            "is_disabled": c.get("isDisabled", False),
+            "group_name": (c.get("group") or {}).get("name"),
+            "group_type": (c.get("group") or {}).get("type"),
+        }
+        for c in categories.get("categories", [])
+    ]
+    return json.dumps(slim, indent=2)
 
 
 @mcp.tool()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ WRITE_TOOL_NAMES = frozenset({
     "set_budget_amount", "update_transaction_splits",
     "create_transaction_category", "delete_transaction_category",
     "create_manual_account", "update_account", "delete_account",
+    "create_transaction_rule",
 })
 
 

--- a/tests/test_categories.py
+++ b/tests/test_categories.py
@@ -26,6 +26,23 @@ SAMPLE_CATEGORIES = {
     ]
 }
 
+SAMPLE_CATEGORIES_WITH_DISABLED = {
+    "categories": [
+        {
+            "id": "cat-1",
+            "name": "Groceries",
+            "isDisabled": False,
+            "group": {"id": "grp-1", "name": "Food & Drink", "type": "expense"},
+        },
+        {
+            "id": "cat-old",
+            "name": "Old Category",
+            "isDisabled": True,
+            "group": {"id": "grp-1", "name": "Food & Drink", "type": "expense"},
+        },
+    ]
+}
+
 SAMPLE_GROUPS = {
     "categoryGroups": [
         {"id": "grp-1", "name": "Food & Drink", "order": 0, "type": "expense"},
@@ -46,9 +63,43 @@ async def test_get_categories_happy(mcp_client, mock_monarch_client):
         (await mcp_client.call_tool("get_transaction_categories")).content[0].text
     )
 
-    assert len(result["categories"]) == 2
-    assert result["categories"][0]["name"] == "Groceries"
+    assert len(result) == 2
+    assert result[0]["id"] == "cat-1"
+    assert result[0]["name"] == "Groceries"
+    assert result[0]["is_disabled"] is False
+    assert result[0]["group_name"] == "Food & Drink"
+    assert result[0]["group_type"] == "expense"
+    assert "order" not in result[0]
+    assert "isSystemCategory" not in result[0]
     mock_monarch_client.get_transaction_categories.assert_called_once()
+
+
+async def test_get_categories_is_disabled(mcp_client, mock_monarch_client):
+    mock_monarch_client.get_transaction_categories.return_value = (
+        SAMPLE_CATEGORIES_WITH_DISABLED
+    )
+
+    result = json.loads(
+        (await mcp_client.call_tool("get_transaction_categories")).content[0].text
+    )
+
+    assert result[0]["is_disabled"] is False
+    assert result[1]["is_disabled"] is True
+
+
+async def test_get_categories_missing_fields(mcp_client, mock_monarch_client):
+    mock_monarch_client.get_transaction_categories.return_value = {
+        "categories": [{"id": "cat-x", "name": "Partial"}]
+    }
+
+    result = json.loads(
+        (await mcp_client.call_tool("get_transaction_categories")).content[0].text
+    )
+
+    assert result[0]["id"] == "cat-x"
+    assert result[0]["is_disabled"] is False
+    assert result[0]["group_name"] is None
+    assert result[0]["group_type"] is None
 
 
 async def test_get_categories_empty(mcp_client, mock_monarch_client):
@@ -58,7 +109,7 @@ async def test_get_categories_empty(mcp_client, mock_monarch_client):
         (await mcp_client.call_tool("get_transaction_categories")).content[0].text
     )
 
-    assert result["categories"] == []
+    assert result == []
 
 
 async def test_get_categories_error(mcp_client, mock_monarch_client):

--- a/tests/test_transaction_rules.py
+++ b/tests/test_transaction_rules.py
@@ -1,0 +1,302 @@
+"""Tests for create_transaction_rule tool."""
+# pylint: disable=missing-function-docstring
+
+import json
+
+
+# ===================================================================
+# 1 – happy path: merchant name "contains"
+# ===================================================================
+
+
+async def test_create_rule_merchant_contains(mcp_write_client, mock_monarch_client):
+    mock_monarch_client.gql_call.return_value = {
+        "createTransactionRuleV2": {"errors": []}
+    }
+
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "create_transaction_rule",
+            {
+                "set_category_id": "cat-123",
+                "merchant_name_value": "Amazon",
+            },
+        )).content[0].text
+    )
+
+    assert result["created"] is True
+    call_kwargs = mock_monarch_client.gql_call.call_args[1]
+    assert call_kwargs["operation"] == "Common_CreateTransactionRuleMutationV2"
+    variables = call_kwargs["variables"]
+    assert variables["input"]["merchantNameCriteria"] == [
+        {"operator": "contains", "value": "Amazon"}
+    ]
+    assert variables["input"]["setCategoryAction"] == "cat-123"
+    assert variables["input"]["applyToExistingTransactions"] is False
+
+
+# ===================================================================
+# 2 – happy path: merchant name "eq"
+# ===================================================================
+
+
+async def test_create_rule_merchant_eq(mcp_write_client, mock_monarch_client):
+    mock_monarch_client.gql_call.return_value = {
+        "createTransactionRuleV2": {"errors": []}
+    }
+
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "create_transaction_rule",
+            {
+                "set_category_id": "cat-456",
+                "merchant_name_value": "contribution",
+                "merchant_name_operator": "eq",
+            },
+        )).content[0].text
+    )
+
+    assert result["created"] is True
+    variables = mock_monarch_client.gql_call.call_args[1]["variables"]
+    assert variables["input"]["merchantNameCriteria"] == [
+        {"operator": "eq", "value": "contribution"}
+    ]
+
+
+# ===================================================================
+# 3 – happy path: original statement criteria
+# ===================================================================
+
+
+async def test_create_rule_original_statement(mcp_write_client, mock_monarch_client):
+    mock_monarch_client.gql_call.return_value = {
+        "createTransactionRuleV2": {"errors": []}
+    }
+
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "create_transaction_rule",
+            {
+                "set_category_id": "cat-789",
+                "original_statement_value": "ROLLOVER CASH",
+                "original_statement_operator": "contains",
+            },
+        )).content[0].text
+    )
+
+    assert result["created"] is True
+    variables = mock_monarch_client.gql_call.call_args[1]["variables"]
+    assert variables["input"]["originalStatementCriteria"] == [
+        {"operator": "contains", "value": "ROLLOVER CASH"}
+    ]
+
+
+# ===================================================================
+# 4 – happy path: account_ids scoping
+# ===================================================================
+
+
+async def test_create_rule_with_account_ids(mcp_write_client, mock_monarch_client):
+    mock_monarch_client.gql_call.return_value = {
+        "createTransactionRuleV2": {"errors": []}
+    }
+
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "create_transaction_rule",
+            {
+                "set_category_id": "cat-123",
+                "merchant_name_value": "Fidelity",
+                "account_ids": ["acct-1", "acct-2"],
+            },
+        )).content[0].text
+    )
+
+    assert result["created"] is True
+    variables = mock_monarch_client.gql_call.call_args[1]["variables"]
+    assert variables["input"]["accountIds"] == ["acct-1", "acct-2"]
+
+
+# ===================================================================
+# 5 – happy path: apply_to_existing_transactions = True
+# ===================================================================
+
+
+async def test_create_rule_apply_to_existing(mcp_write_client, mock_monarch_client):
+    mock_monarch_client.gql_call.return_value = {
+        "createTransactionRuleV2": {"errors": []}
+    }
+
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "create_transaction_rule",
+            {
+                "set_category_id": "cat-123",
+                "merchant_name_value": "Whole Foods",
+                "apply_to_existing_transactions": True,
+            },
+        )).content[0].text
+    )
+
+    assert result["created"] is True
+    variables = mock_monarch_client.gql_call.call_args[1]["variables"]
+    assert variables["input"]["applyToExistingTransactions"] is True
+
+
+# ===================================================================
+# 6 – validation: no criteria provided
+# ===================================================================
+
+
+async def test_create_rule_no_criteria(mcp_write_client, mock_monarch_client):
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "create_transaction_rule",
+            {"set_category_id": "cat-123"},
+        )).content[0].text
+    )
+
+    assert "error" in result
+    mock_monarch_client.gql_call.assert_not_called()
+
+
+# ===================================================================
+# 7 – validation: invalid merchant_name_operator
+# ===================================================================
+
+
+async def test_create_rule_invalid_merchant_operator(mcp_write_client, mock_monarch_client):
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "create_transaction_rule",
+            {
+                "set_category_id": "cat-123",
+                "merchant_name_value": "Amazon",
+                "merchant_name_operator": "startswith",
+            },
+        )).content[0].text
+    )
+
+    assert "error" in result
+    mock_monarch_client.gql_call.assert_not_called()
+
+
+# ===================================================================
+# 8 – validation: invalid original_statement_operator
+# ===================================================================
+
+
+async def test_create_rule_invalid_statement_operator(mcp_write_client, mock_monarch_client):
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "create_transaction_rule",
+            {
+                "set_category_id": "cat-123",
+                "original_statement_value": "ROLLOVER",
+                "original_statement_operator": "regex",
+            },
+        )).content[0].text
+    )
+
+    assert "error" in result
+    mock_monarch_client.gql_call.assert_not_called()
+
+
+# ===================================================================
+# 9 – API-level error: errors as list
+# ===================================================================
+
+
+async def test_create_rule_api_error_list(mcp_write_client, mock_monarch_client):
+    mock_monarch_client.gql_call.return_value = {
+        "createTransactionRuleV2": {
+            "errors": [{"message": "Category not found"}]
+        }
+    }
+
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "create_transaction_rule",
+            {
+                "set_category_id": "cat-bad",
+                "merchant_name_value": "Amazon",
+            },
+        )).content[0].text
+    )
+
+    assert "error" in result
+    assert "Category not found" in result["error"]
+
+
+# ===================================================================
+# 9b – API-level error: errors as bare dict (Monarch's actual shape)
+# ===================================================================
+
+
+async def test_create_rule_api_error_dict(mcp_write_client, mock_monarch_client):
+    mock_monarch_client.gql_call.return_value = {
+        "createTransactionRuleV2": {
+            "errors": {"message": "Invalid operator"}
+        }
+    }
+
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "create_transaction_rule",
+            {
+                "set_category_id": "cat-123",
+                "merchant_name_value": "Amazon",
+                "merchant_name_operator": "contains",
+            },
+        )).content[0].text
+    )
+
+    assert "error" in result
+    assert "Invalid operator" in result["error"]
+
+
+# ===================================================================
+# 10 – transport error handled by decorator
+# ===================================================================
+
+
+async def test_create_rule_transport_error(mcp_write_client, mock_monarch_client):
+    mock_monarch_client.gql_call.side_effect = Exception("Network failure")
+
+    result = (await mcp_write_client.call_tool(
+        "create_transaction_rule",
+        {
+            "set_category_id": "cat-123",
+            "merchant_name_value": "Amazon",
+        },
+    )).content[0].text
+
+    assert "Error" in result
+    assert "Network failure" in result
+
+
+# ===================================================================
+# 11 – both merchant name and original statement provided together
+# ===================================================================
+
+
+async def test_create_rule_both_criteria(mcp_write_client, mock_monarch_client):
+    mock_monarch_client.gql_call.return_value = {
+        "createTransactionRuleV2": {"errors": []}
+    }
+
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "create_transaction_rule",
+            {
+                "set_category_id": "cat-123",
+                "merchant_name_value": "Fidelity",
+                "original_statement_value": "ROLLOVER CASH",
+            },
+        )).content[0].text
+    )
+
+    assert result["created"] is True
+    variables = mock_monarch_client.gql_call.call_args[1]["variables"]
+    assert "merchantNameCriteria" in variables["input"]
+    assert "originalStatementCriteria" in variables["input"]


### PR DESCRIPTION
## Summary

- Adds a new \`create_transaction_rule\` write tool that creates Monarch Money transaction rules via the \`Common_CreateTransactionRuleMutationV2\` GraphQL mutation
- Implemented via \`gql_call\` (same pattern as \`delete_transaction_tag\`) since the \`monarchmoneycommunity\` library does not expose rule management
- The mutation was sourced from the Monarch SPA JS bundle, as introspection is disabled for non-admin users
- Slims \`get_transaction_categories\` response from ~10k to ~1-2k tokens by dropping noise fields

**\`create_transaction_rule\` parameters:**
- \`set_category_id\` — category ID to assign when the rule matches (required)
- \`merchant_name_value\` + \`merchant_name_operator\` (\`"contains"\` / \`"eq"\` — regex is not supported by the API)
- \`original_statement_value\` + \`original_statement_operator\` (\`"contains"\` / \`"eq"\`)
- \`account_ids\` — restrict rule to specific accounts (optional)
- \`apply_to_existing_transactions\` — backfill past matching transactions (default \`false\`)

API-level errors are surfaced to the caller, including the bare-dict error shape Monarch returns for invalid operators (e.g. \`{"message": "Invalid operator"}\` instead of a list).

**\`get_transaction_categories\` response** is now a flat list with only useful fields: \`id\`, \`name\`, \`is_disabled\`, \`group_name\`, \`group_type\`.

## Test plan

- [x] 12 unit tests in \`tests/test_transaction_rules.py\` — happy paths, input validation, API errors (list and bare-dict shapes), transport errors
- [x] \`test_categories.py\` updated to assert the slimmed response shape
- [x] All 252 tests pass
- [x] pylint 10.00/10
- [x] Live-tested rule creation against the Monarch API — confirmed \`"eq"\` and \`"contains"\` work; confirmed regex operators return \`"Invalid operator"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)