### PR TITLE
Slim get_transactions response to reduce token usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,10 +74,3 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-
-[dependency-groups]
-dev = [
-    "pylint>=4.0.4",
-    "pytest>=8.4.2",
-    "pytest-asyncio>=1.1.0",
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,3 +74,10 @@ testpaths = ["tests"]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
+
+[dependency-groups]
+dev = [
+    "pylint>=4.0.4",
+    "pytest>=8.4.2",
+    "pytest-asyncio>=1.1.0",
+]

--- a/src/monarch_mcp/server.py
+++ b/src/monarch_mcp/server.py
@@ -327,10 +327,10 @@ def get_transactions(  # pylint: disable=too-many-arguments,too-many-positional-
 
     transactions = run_with_auth_recovery(_get_transactions())
 
-    # Format transactions for display
+    # Format transactions for display — omit falsy/empty fields to reduce response size
     transaction_list = []
     for txn in transactions.get("allTransactions", {}).get("results", []):
-        transaction_info = {
+        transaction_info: Dict[str, Any] = {
             "id": txn.get("id"),
             "date": txn.get("date"),
             "amount": txn.get("amount"),
@@ -342,21 +342,24 @@ def get_transactions(  # pylint: disable=too-many-arguments,too-many-positional-
             "merchant": txn.get("merchant", {}).get("name")
             if txn.get("merchant")
             else None,
-            "notes": txn.get("notes"),
-            "is_pending": txn.get("pending", False),
-            "is_recurring": txn.get("isRecurring", False),
-            "tags": [
-                {
-                    "id": tag.get("id"),
-                    "name": tag.get("name"),
-                    "color": tag.get("color"),
-                }
-                for tag in txn.get("tags", [])
-            ],
         }
+        # Only include optional fields when they carry signal
+        if txn.get("notes"):
+            transaction_info["notes"] = txn["notes"]
+        if txn.get("pending"):
+            transaction_info["is_pending"] = True
+        if txn.get("isRecurring"):
+            transaction_info["is_recurring"] = True
+        if txn.get("needsReview"):
+            transaction_info["needs_review"] = True
+        tags = txn.get("tags") or []
+        if tags:
+            transaction_info["tags"] = [
+                {"id": t.get("id"), "name": t.get("name")} for t in tags
+            ]
         transaction_list.append(transaction_info)
 
-    return json.dumps(transaction_list, indent=2, default=str)
+    return json.dumps(transaction_list, separators=(",", ":"), default=str)
 
 
 @mcp.tool()

--- a/tests/test_transactions_read.py
+++ b/tests/test_transactions_read.py
@@ -22,6 +22,7 @@ def _make_txn(i, **overrides):
         "notes": None,
         "pending": False,
         "isRecurring": False,
+        "needsReview": False,
         "tags": [],
     }
     txn.update(overrides)
@@ -440,3 +441,59 @@ async def test_needs_review_false(mcp_client, mock_monarch_client):
     assert "error" in result
     assert "monarchmoneycommunity" in result["error"]
     mock_monarch_client.get_transactions.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 3.25 – slim response: falsy fields omitted, compact JSON
+# ---------------------------------------------------------------------------
+
+
+async def test_slim_response_omits_falsy_fields(mcp_client, mock_monarch_client):
+    mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
+
+    raw = (await mcp_client.call_tool("get_transactions", {"limit": 1})).content[0].text
+    result = json.loads(raw)
+
+    txn = result[0]
+    # Always-present fields
+    assert txn["id"] == "txn-0"
+    assert txn["date"] == "2025-01-15"
+    assert txn["amount"] == -10.0
+    # Omitted when falsy
+    assert "notes" not in txn
+    assert "is_pending" not in txn
+    assert "is_recurring" not in txn
+    assert "needs_review" not in txn
+    assert "tags" not in txn
+    # Compact JSON — no leading whitespace
+    assert not raw.startswith("[\n")
+
+
+# ---------------------------------------------------------------------------
+# 3.26 – slim response: optional fields present when truthy
+# ---------------------------------------------------------------------------
+
+
+async def test_slim_response_includes_truthy_fields(mcp_client, mock_monarch_client):
+    txn = _make_txn(
+        0,
+        notes="split with spouse",
+        pending=True,
+        isRecurring=True,
+        needsReview=True,
+        tags=[{"id": "t1", "name": "Vacation", "color": "#FF0000"}],
+    )
+    mock_monarch_client.get_transactions.return_value = _wrap([txn])
+
+    result = json.loads(
+        (await mcp_client.call_tool("get_transactions", {"limit": 1})).content[0].text
+    )
+
+    txn_out = result[0]
+    assert txn_out["notes"] == "split with spouse"
+    assert txn_out["is_pending"] is True
+    assert txn_out["is_recurring"] is True
+    assert txn_out["needs_review"] is True
+    assert txn_out["tags"] == [{"id": "t1", "name": "Vacation"}]
+    # color must be stripped
+    assert "color" not in txn_out["tags"][0]

--- a/uv.lock
+++ b/uv.lock
@@ -633,7 +633,7 @@ wheels = [
 
 [[package]]
 name = "gql"
-version = "3.5.3"
+version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -641,9 +641,9 @@ dependencies = [
     { name = "graphql-core" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/ed/44ffd30b06b3afc8274ee2f38c3c1b61fe4740bf03d92083e43d2c17ac77/gql-3.5.3.tar.gz", hash = "sha256:393b8c049d58e0d2f5461b9d738a2b5f904186a40395500b4a84dd092d56e42b", size = 180504, upload-time = "2025-05-20T12:34:08.954Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/9f/cf224a88ed71eb223b7aa0b9ff0aa10d7ecc9a4acdca2279eb046c26d5dc/gql-4.0.0.tar.gz", hash = "sha256:f22980844eb6a7c0266ffc70f111b9c7e7c7c13da38c3b439afc7eab3d7c9c8e", size = 215644, upload-time = "2025-08-17T14:32:35.397Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/50/2f4e99b216821ac921dbebf91c644ba95818f5d07857acadee17220221f3/gql-3.5.3-py2.py3-none-any.whl", hash = "sha256:e1fcbde2893fcafdd28114ece87ff47f1cc339a31db271fc4e1d528f5a1d4fbc", size = 74348, upload-time = "2025-05-20T12:34:07.687Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/94/30bbd09e8d45339fa77a48f5778d74d47e9242c11b3cd1093b3d994770a5/gql-4.0.0-py3-none-any.whl", hash = "sha256:f3beed7c531218eb24d97cb7df031b4a84fdb462f4a2beb86e2633d395937479", size = 89900, upload-time = "2025-08-17T14:32:34.029Z" },
 ]
 
 [[package]]
@@ -968,6 +968,13 @@ dev = [
     { name = "pytest-cov" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pylint" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "asyncio", specifier = ">=3.4.3" },
@@ -975,7 +982,7 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=2.12.0,<3.0.0" },
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.12.0" },
     { name = "keyring", specifier = ">=24.0.0" },
-    { name = "monarchmoneycommunity", specifier = "~=1.3.0" },
+    { name = "monarchmoneycommunity", specifier = "==1.3.1" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
@@ -987,18 +994,25 @@ requires-dist = [
 ]
 provides-extras = ["dev"]
 
+[package.metadata.requires-dev]
+dev = [
+    { name = "pylint", specifier = ">=4.0.4" },
+    { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-asyncio", specifier = ">=1.1.0" },
+]
+
 [[package]]
 name = "monarchmoneycommunity"
-version = "1.3.0"
+version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
     { name = "gql" },
     { name = "oathtool" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/60/6dea6eebbfc814cfefb9a5e9cbe983b45ace907c7eb29db60d93b8387759/monarchmoneycommunity-1.3.0.tar.gz", hash = "sha256:f771bdfe66ce0ea45e30b4b324d017bcbc85cc81db8c5af9c3f788171cde18dc", size = 27931, upload-time = "2026-02-11T02:53:15.343Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/0d/65f245d117c9ba92722923dae0b01bd94ca9a4cc3b2b65f8cdbec5e07da1/monarchmoneycommunity-1.3.1.tar.gz", hash = "sha256:e9ab66db9a04d02a4f4de8d3cf8f62e5be9dda83ac1cc22c491506e00aa3ea6f", size = 28062, upload-time = "2026-03-23T23:51:31.733Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/3c/451fb2af0930de84ae2f631bc9ae9f7b0f883548e507e7e68c5ac36b7cdb/monarchmoneycommunity-1.3.0-py3-none-any.whl", hash = "sha256:57df2fc8c8d2db57a2d38d1bd1ff1514e2f871ac6ed1db60ec8d551dbe576a08", size = 22772, upload-time = "2026-02-11T02:53:13.676Z" },
+    { url = "https://files.pythonhosted.org/packages/42/50/6533745a1634faed43dcd56ead0b535be0fcdcd0878fed064ed5e62a5d31/monarchmoneycommunity-1.3.1-py3-none-any.whl", hash = "sha256:9b09c8971042eef73b28e4e02eedb82fba20db0551930aca70ef2fe64c4a5e3e", size = 22792, upload-time = "2026-03-23T23:51:30.507Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Reduces the token footprint of `get_transactions` responses, which were blowing up context on large result sets.

**Changes per transaction:**
- Omit `notes`, `is_pending`, `is_recurring`, `needs_review`, `tags` when falsy — most transactions have none of these set
- Add `needs_review` to response when `true` (was missing entirely)
- Drop `tags[].color` — noise field, never needed by callers
- Switch from `indent=2` to compact JSON (`separators=(",",":")`) — the biggest win; with 100 transactions, indentation alone costs thousands of tokens

## Test plan

- [x] Test 3.25: falsy fields omitted, compact JSON verified
- [x] Test 3.26: truthy fields included, `tags[].color` stripped
- [x] All 242 tests pass
- [x] pylint 10.00/10

🤖 Generated with [Claude Code](https://claude.com/claude-code)