### PR TITLE
Remove needs_review guard now that monarchmoneycommunity 1.3.2 is released

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 requires-python = ">=3.12,<3.14"
 dependencies = [
     "fastmcp>=2.12.0,<3.0.0",
-    "monarchmoneycommunity==1.3.1",
+    "monarchmoneycommunity==1.3.2",
     "keyring>=24.0.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 requires-python = ">=3.12,<3.14"
 dependencies = [
     "fastmcp>=2.12.0,<3.0.0",
-    "monarchmoneycommunity==1.3.2",
+    "monarchmoneycommunity~=1.3.2",
     "keyring>=24.0.0",
     "python-dotenv>=1.0.0",
     "pydantic>=2.0.0",

--- a/src/monarch_mcp/server.py
+++ b/src/monarch_mcp/server.py
@@ -271,13 +271,6 @@ def get_transactions(  # pylint: disable=too-many-arguments,too-many-positional-
         synced_from_institution: Filter synced/manual transactions
         needs_review: Filter transactions that need review
     """
-    if needs_review is not None:
-        return json.dumps(
-            {"error": "needs_review filter is not yet supported by the installed version of "
-                      "monarchmoneycommunity. It will be available in the next library release."},
-            indent=2,
-        )
-
     if bool(start_date) != bool(end_date):
         return json.dumps(
             {"error": "Both start_date and end_date are required when filtering by date."},

--- a/tests/test_transactions_read.py
+++ b/tests/test_transactions_read.py
@@ -436,9 +436,11 @@ async def test_needs_review_true(mcp_client, mock_monarch_client):
 async def test_needs_review_false(mcp_client, mock_monarch_client):
     mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
 
-    assert "error" in result
-    assert "monarchmoneycommunity" in result["error"]
-    mock_monarch_client.get_transactions.assert_not_called()
+    await mcp_client.call_tool("get_transactions", {"needs_review": False})
+
+    mock_monarch_client.get_transactions.assert_called_once_with(
+        limit=100, offset=0, needs_review=False
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_transactions_read.py
+++ b/tests/test_transactions_read.py
@@ -414,29 +414,27 @@ async def test_combined_search_and_filters(mcp_client, mock_monarch_client):
 
 
 # ---------------------------------------------------------------------------
-# 3.23 – needs_review=True returns not-yet-supported error
+# 3.23 – needs_review=True is passed through to the library
 # ---------------------------------------------------------------------------
 
 
 async def test_needs_review_true(mcp_client, mock_monarch_client):
-    result = json.loads(
-        (await mcp_client.call_tool("get_transactions", {"needs_review": True})).content[0].text
-    )
+    mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
 
-    assert "error" in result
-    assert "monarchmoneycommunity" in result["error"]
-    mock_monarch_client.get_transactions.assert_not_called()
+    await mcp_client.call_tool("get_transactions", {"needs_review": True})
+
+    mock_monarch_client.get_transactions.assert_called_once_with(
+        limit=100, offset=0, needs_review=True
+    )
 
 
 # ---------------------------------------------------------------------------
-# 3.24 – needs_review=False returns not-yet-supported error
+# 3.24 – needs_review=False is passed through to the library
 # ---------------------------------------------------------------------------
 
 
 async def test_needs_review_false(mcp_client, mock_monarch_client):
-    result = json.loads(
-        (await mcp_client.call_tool("get_transactions", {"needs_review": False})).content[0].text
-    )
+    mock_monarch_client.get_transactions.return_value = _wrap([_make_txn(0)])
 
     assert "error" in result
     assert "monarchmoneycommunity" in result["error"]


### PR DESCRIPTION
## Summary

Follow-up to #29.

When `needs_review` was merged in #29, the `monarchmoneycommunity` library hadn't yet cut a release with the parameter — it was on `main` but missed v1.3.1 (released the same day). A temporary guard was added to return a clear error message rather than a cryptic library exception.

v1.3.2 is now published and includes `needs_review`. This PR:

- Removes the early-return guard from `get_transactions`
- Bumps `monarchmoneycommunity` 1.3.1 → 1.3.2
- Updates tests 3.23 and 3.24 to assert that `needs_review=True/False` is passed through to the library (rather than asserting the error response)

## Test plan

- [x] 240 tests pass
- [x] pylint 10.00/10