### PR TITLE
feat: expose recurring-merchant management tools

### DIFF
--- a/.claude/skills/test-monarch-mcp/SKILL.md
+++ b/.claude/skills/test-monarch-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-monarch-mcp
-description: Systematically test Monarch Money MCP tools in read-only mode (27 tools, 54 tests) or write-enabled mode (all 42 tools, 101 tests). Account-agnostic (discovers IDs at runtime) and self-cleaning (deletes everything it creates in write mode). Batches each phase into a subagent so large tool payloads stay out of the orchestrator's context.
+description: Systematically test Monarch Money MCP tools in read-only mode (28 tools, 58 tests) or write-enabled mode (all 44 tools, 109 tests). Account-agnostic (discovers IDs at runtime) and self-cleaning (deletes everything it creates in write mode). Batches each phase into a subagent so large tool payloads stay out of the orchestrator's context.
 user_invocable: true
 ---
 
@@ -14,7 +14,7 @@ compact PASS/FAIL summary. You aggregate the summaries, track created resources,
 print the final report. This keeps large tool payloads (transaction lists, rule lists, full objects)
 inside the subagents and out of your context.
 
-Run tests across 13 phases, track results, and clean up after yourself.
+Run tests across 14 phases, track results, and clean up after yourself.
 
 > **Scope of this skill:** it validates that the **agent** uses the MCP tools correctly — right tool,
 > right params, correct interpretation of responses (happy paths, agent-judgment cases, and one
@@ -28,9 +28,9 @@ Run tests across 13 phases, track results, and clean up after yourself.
 
 This test suite supports two modes, auto-detected at startup:
 
-- **Read-only mode** (default): Tests 27 read-only tools (54 tests). Write-dependent tests are
+- **Read-only mode** (default): Tests 28 read-only tools (58 tests). Write-dependent tests are
   skipped. No data is created, modified, or deleted.
-- **Write-enabled mode** (`--enable-write`): Tests all 42 tools (101 tests). Creates, modifies, and
+- **Write-enabled mode** (`--enable-write`): Tests all 44 tools (109 tests). Creates, modifies, and
   deletes data on your live Monarch account. Self-cleaning.
 
 ---
@@ -120,10 +120,11 @@ Use the Task tool (subagent type: `general-purpose`). The prompt you pass must c
 | 7 | Transaction Tagging | `references/transaction-tagging.md` | — (skip) | yes |
 | 8 | Categories | `references/categories.md` | 8.1–8.3 | yes |
 | 9 | Details & Splits | `references/transaction-details-and-splits.md` | 9.1–9.4 | yes (9.5–9.7) |
-| 10 | Read-Only Tools | `references/read-only-tools.md` | all (9) | no |
+| 10 | Read-Only Tools | `references/read-only-tools.md` | all (12) | no |
 | 11 | Account Management | `references/account-management.md` | 11.1, 11.6-alt, 11.7–11.10 | yes |
 | 12 | Analytics | `references/analytics-tools.md` | all (5) | no |
 | 13 | Transaction Rules | `references/transaction-rules.md` | 13.7 | yes |
+| 14 | Recurring Merchant Management | `references/recurring-merchant.md` | 14.1 | yes |
 
 > **Phase 11 read-only note:** run **11.6-alt** instead of 11.6 — it calls `get_account_history` with
 > `{checking_account_id}` because no account is created in read-only mode.
@@ -179,7 +180,7 @@ The state file is `mcp-test-state.json` in the project root.
   },
   "results": {},
   "summary": {
-    "total": 101,
+    "total": 109,
     "passed": 0,
     "failed": 0,
     "skipped": 0
@@ -187,8 +188,8 @@ The state file is `mcp-test-state.json` in the project root.
 }
 ```
 
-In **read-only mode**, `summary.total` is `54` and `original_values` is omitted (no mutations happen).
-In **write-enabled mode**, `summary.total` is `101`.
+In **read-only mode**, `summary.total` is `58` and `original_values` is omitted (no mutations happen).
+In **write-enabled mode**, `summary.total` is `109`.
 
 ### Update Cadence
 
@@ -225,8 +226,8 @@ Before starting any test work (including Phase 0), detect the server mode and ge
 ### Mode Detection (Phase 0 preamble)
 
 Check which MCP tools are available. If write tools like `create_transaction`, `create_transaction_tag`,
-`delete_transaction`, etc. are available, the server is in **read-write mode**. If they are absent, the
-server is in **read-only mode**.
+`delete_transaction`, `update_recurring_merchant`, etc. are available, the server is in **read-write mode**.
+If they are absent, the server is in **read-only mode**.
 
 ### User Confirmation
 
@@ -237,12 +238,12 @@ approval**:
 
 ---
 
-**Server is running in read-only mode (27 tools).**
+**Server is running in read-only mode (28 tools).**
 
-I'll run 54 read-only tests and skip 47 write tests. No data will be created, modified, or deleted on
+I'll run 58 read-only tests and skip 51 write tests. No data will be created, modified, or deleted on
 your Monarch account.
 
-To test all 101 tests, disable `monarch-money-read-only` and enable `monarch-money` in `.mcp.json`,
+To test all 109 tests, disable `monarch-money-read-only` and enable `monarch-money` in `.mcp.json`,
 then restart.
 
 **Proceed with read-only tests?**
@@ -253,13 +254,13 @@ then restart.
 
 ---
 
-**WARNING: Server is running in read-write mode (all 42 tools).**
+**WARNING: Server is running in read-write mode (all 44 tools).**
 
-I'll run all 101 tests. This will **create, modify, and delete** data on your **live Monarch Money
+I'll run all 109 tests. This will **create, modify, and delete** data on your **live Monarch Money
 account**:
 
 - It **creates and deletes** transactions, tags, categories, and accounts.
-- It **temporarily modifies** an existing transaction (then reverts it).
+- It **temporarily modifies** an existing transaction and one merchant's recurring state (then reverts them).
 - The test is designed to clean up everything it creates, but **if something goes wrong** (network
   error, timeout, context limit), **cleanup may be incomplete** and unwanted changes could remain in
   your account.
@@ -331,7 +332,7 @@ If any required value (`checking_account_id`, `test_transaction_id`, `valid_cate
 
 ---
 
-## Phases 1–13
+## Phases 1–14
 
 For each phase, dispatch a subagent per the **Execution Model** (read-only → concurrent; write →
 sequential). Pass the mode, the read-only subset (from the Phase Map), the discovery values, the
@@ -436,13 +437,14 @@ subagent returns.
 ║ Phase 7  — Tagging:           SKIPPED (write)    ║
 ║ Phase 8  — Categories:        3/3  PASS          ║
 ║ Phase 9  — Details/Splits:    4/4  PASS          ║
-║ Phase 10 — Read-Only Tools:   9/9  PASS          ║
+║ Phase 10 — Read-Only Tools:   12/12 PASS         ║
 ║ Phase 11 — Account Mgmt:      6/6  PASS          ║
 ║ Phase 12 — Analytics:         5/5  PASS          ║
 ║ Phase 13 — Rules:             1/1  PASS          ║
+║ Phase 14 — Recurring Merch:   1/1  PASS          ║
 ╠══════════════════════════════════════════════════╣
-║ TOTAL: 54 passed, 0 failed, 0 skipped           ║
-║ Write tests skipped: 47 (server in read-only)    ║
+║ TOTAL: 58 passed, 0 failed, 0 skipped           ║
+║ Write tests skipped: 51 (server in read-only)    ║
 ╚══════════════════════════════════════════════════╝
 ```
 
@@ -461,12 +463,13 @@ subagent returns.
 ║ Phase 7  — Tagging:           4/4  PASS          ║
 ║ Phase 8  — Categories:        9/9  PASS          ║
 ║ Phase 9  — Details/Splits:    7/7  PASS          ║
-║ Phase 10 — Read-Only Tools:   9/9  PASS          ║
+║ Phase 10 — Read-Only Tools:   12/12 PASS         ║
 ║ Phase 11 — Account Mgmt:      10/10 PASS         ║
 ║ Phase 12 — Analytics:         5/5  PASS          ║
 ║ Phase 13 — Transaction Rules: 10/10 PASS         ║
+║ Phase 14 — Recurring Merch:   5/5  PASS          ║
 ╠══════════════════════════════════════════════════╣
-║ TOTAL: 101 passed, 0 failed, 0 skipped          ║
+║ TOTAL: 109 passed, 0 failed, 0 skipped          ║
 ╚══════════════════════════════════════════════════╝
 ```
 
@@ -508,3 +511,5 @@ into the reference-file test bodies):
 | `{valid_category_id}` | `discovery.valid_category_id` |
 | `{created_tag_id}` | ID returned from the phase's most recent `create_transaction_tag` call (tracked inside the subagent) |
 | `{created_txn_id}` | ID returned from the phase's most recent `create_transaction` call (tracked inside the subagent) |
+| `{recurring_merchant_id}` | `merchant_id` returned by `find_merchant_id_by_name` in Phase 14.1 (tracked inside the subagent) |
+| `{recurring_merchant_name}` | `merchant_name` returned by `find_merchant_id_by_name` in Phase 14.1 (tracked inside the subagent) |

--- a/.claude/skills/test-monarch-mcp/references/read-only-tools.md
+++ b/.claude/skills/test-monarch-mcp/references/read-only-tools.md
@@ -1,4 +1,4 @@
-# Phase 10 — Read-Only Tools (9 tests)
+# Phase 10 — Read-Only Tools (12 tests)
 
 ## 10.1 — get_transactions_summary: returns aggregate stats
 Call `get_transactions_summary()`.
@@ -36,3 +36,23 @@ Call `get_recurring_transactions(start_date="2025-01-01", end_date="2025-12-31")
 Call `get_recurring_transactions(end_date="2025-12-31")`.
 **Expected:** JSON with `error` key.
 
+## 10.10 — find_merchant_id_by_name: returns distinct merchants
+Call `find_merchant_id_by_name(name="amazon")` (substitute any merchant name likely to appear in your transactions; fallback: pick a name from a recent `get_transactions(limit=10)` result).
+**Expected:** JSON array. Each entry has `merchant_id`, `merchant_name`, plus optional `sample_amount`, `sample_date`, `sample_account`. IDs are distinct (no duplicates within the array).
+
+**Validation:**
+- Response is a JSON list (may be empty if the search yields no matches).
+- Every entry includes a non-null `merchant_id`.
+- No `merchant_id` appears twice.
+
+## 10.11 — find_merchant_id_by_name: respects limit
+Call `find_merchant_id_by_name(name="amazon", limit=1)` (use the same query as 10.10).
+**Expected:** JSON array with at most 1 entry.
+
+**Validation:** `len(result) <= 1`.
+
+## 10.12 — find_merchant_id_by_name: empty for nonsense query
+Call `find_merchant_id_by_name(name="zzzz-no-such-merchant-zzzz")`.
+**Expected:** Empty JSON array `[]`. No crash.
+
+**Validation:** Response parses as a list with length 0.

--- a/.claude/skills/test-monarch-mcp/references/recurring-merchant.md
+++ b/.claude/skills/test-monarch-mcp/references/recurring-merchant.md
@@ -51,16 +51,22 @@ update_recurring_merchant(
 
 ## 14.3 — update_recurring_merchant: deactivate the recurrence (write only)
 
+> **Note:** `is_recurring` is **required** on every call. Adjusting an existing recurrence (here,
+> switching it off) keeps `is_recurring=true` and passes only the field being changed — Monarch keeps
+> the rest of the schedule. Omitting `is_recurring` is what produced the opaque "Something went wrong"
+> error before the fix.
+
 **Tool call:**
 ```
 update_recurring_merchant(
-  merchant_id = "{recurring_merchant_id}",
-  name        = "{recurring_merchant_name}",
-  is_active   = false
+  merchant_id  = "{recurring_merchant_id}",
+  name         = "{recurring_merchant_name}",
+  is_recurring = true,
+  is_active    = false
 )
 ```
 
-**Expected:** Response indicates success. The merchant's recurring entry stays defined but is no longer surfaced as an active bill.
+**Expected:** Response indicates success. The merchant's recurring entry stays defined but is no longer surfaced as an active bill (`recurringTransactionStream.isActive` is false).
 
 **Validation:** Response is a non-error JSON object.
 
@@ -71,14 +77,15 @@ update_recurring_merchant(
 **Tool call:**
 ```
 update_recurring_merchant(
-  merchant_id = "{recurring_merchant_id}",
-  name        = "{recurring_merchant_name}",
-  is_active   = true,
-  amount      = -12.49
+  merchant_id  = "{recurring_merchant_id}",
+  name         = "{recurring_merchant_name}",
+  is_recurring = true,
+  is_active    = true,
+  amount       = -12.49
 )
 ```
 
-**Expected:** Response indicates success.
+**Expected:** Response indicates success. The recurrence is active again with the new amount; the unchanged frequency/base_date are preserved by Monarch.
 
 **Validation:** Response is a non-error JSON object.
 

--- a/.claude/skills/test-monarch-mcp/references/recurring-merchant.md
+++ b/.claude/skills/test-monarch-mcp/references/recurring-merchant.md
@@ -1,0 +1,111 @@
+# Phase 14 — Recurring Merchant Management (5 tests)
+
+**Read-only mode:** Run test 14.1 only (1 test). Skip 14.2-14.5 (`update_recurring_merchant` requires write mode).
+
+This phase exercises the merchant-level recurring management tools that back Monarch's "Recurring transactions" list. The flow is: discover a merchant ID via `find_merchant_id_by_name`, then mutate it via `update_recurring_merchant`.
+
+**Pick a safe target merchant.** Prefer a merchant that is **not** already in `get_recurring_transactions`, so the test starts from a clean non-recurring baseline and the self-cleanup at the end fully restores it. Before mutating, record the merchant's original `is_recurring` state so the Self-cleanup step can revert it.
+
+---
+
+## 14.1 — find_merchant_id_by_name: discover the test merchant
+
+**Pre-requisite:** Pick a merchant name that appears in your account's recent transactions. If you ran Phase 3, reuse a merchant name from those results.
+
+**Tool call:**
+```
+find_merchant_id_by_name(name = "{merchant_query}", limit = 5)
+```
+
+**Expected:** JSON array with at least one entry. Each entry has `merchant_id`, `merchant_name`, and optional sample fields.
+
+**Validation:**
+- Response is a JSON list.
+- The first entry has a non-empty `merchant_id`.
+- All `merchant_id` values are distinct.
+
+**Immediately after:** Save the first entry's `merchant_id` and `merchant_name` as `{recurring_merchant_id}` and `{recurring_merchant_name}` for the remaining tests. Note whether this merchant is currently listed by `get_recurring_transactions` (its original `is_recurring` state) so the Self-cleanup step can restore it.
+
+---
+
+## 14.2 — update_recurring_merchant: mark merchant as recurring (write only)
+
+**Tool call:**
+```
+update_recurring_merchant(
+  merchant_id  = "{recurring_merchant_id}",
+  name         = "{recurring_merchant_name}",
+  is_recurring = true,
+  frequency    = "monthly",
+  base_date    = "2025-01-15",
+  amount       = -9.99,
+  is_active    = true
+)
+```
+
+**Expected:** JSON response with an `updateMerchant` (or similar) key containing the updated merchant. No `errors`.
+
+**Validation:** Response indicates success. The merchant's `id` matches `{recurring_merchant_id}`.
+
+---
+
+## 14.3 — update_recurring_merchant: deactivate the recurrence (write only)
+
+**Tool call:**
+```
+update_recurring_merchant(
+  merchant_id = "{recurring_merchant_id}",
+  name        = "{recurring_merchant_name}",
+  is_active   = false
+)
+```
+
+**Expected:** Response indicates success. The merchant's recurring entry stays defined but is no longer surfaced as an active bill.
+
+**Validation:** Response is a non-error JSON object.
+
+---
+
+## 14.4 — update_recurring_merchant: reactivate and adjust amount (write only)
+
+**Tool call:**
+```
+update_recurring_merchant(
+  merchant_id = "{recurring_merchant_id}",
+  name        = "{recurring_merchant_name}",
+  is_active   = true,
+  amount      = -12.49
+)
+```
+
+**Expected:** Response indicates success.
+
+**Validation:** Response is a non-error JSON object.
+
+---
+
+## 14.5 — update_recurring_merchant: clear the recurring flag (write only)
+
+**Tool call:**
+```
+update_recurring_merchant(
+  merchant_id  = "{recurring_merchant_id}",
+  name         = "{recurring_merchant_name}",
+  is_recurring = false
+)
+```
+
+**Expected:** Response indicates success. The merchant no longer appears as a recurring bill.
+
+**Validation:** Response is a non-error JSON object.
+
+---
+
+## Self-cleanup (write mode)
+
+After the tests, restore the test merchant to the original `is_recurring` state captured in 14.1:
+
+- **Originally non-recurring** (the recommended target): 14.5 already left it non-recurring — no further action needed. Confirm it is absent from `get_recurring_transactions`.
+- **Originally recurring** (only if no non-recurring merchant was available): best-effort re-flag it with `update_recurring_merchant(merchant_id=..., name=..., is_recurring=true, is_active=true)`. The pre-test frequency/base_date/amount are not recoverable from the read tools, so note any residual change in the return so the orchestrator can warn the user.
+
+Report the restore outcome in the subagent's `self_cleanup` field.

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ Create a tag called "Business Expenses" in red
 | `update_transaction` | Update existing transaction | write |
 | `delete_transaction` | Delete a transaction | write |
 | `update_transaction_splits` | Create/modify/delete splits | write |
-| `update_recurring_merchant` | Mark/unmark a merchant as recurring, update its frequency/amount, or deactivate it (requires `--enable-write`) | write |
+| `update_recurring_merchant` | Mark/unmark a merchant as recurring, update its frequency/amount, or deactivate it — `is_recurring` is required on every call (requires `--enable-write`) | write |
 | **Tags** | | |
 | `get_transaction_tags` | Get all tags | read |
 | `create_transaction_tag` | Create new tag | write |

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Model Context Protocol (MCP) server for integrating with the Monarch Money per
 
 - **Secure by design** — browser-based login, token stored in OS keychain (never in config files or env vars)
 - **Safe by default** — read-only mode prevents accidental changes; write tools require explicit opt-in
-- **Comprehensive** — 38 tools covering accounts, transactions, splits, budgets, cashflow, tags, categories, rules, and credit history
+- **Comprehensive** — 40 tools covering accounts, transactions, splits, budgets, cashflow, tags, categories, rules, recurring merchants, and credit history
 - **Easy to install** — Claude Desktop extension (`.mcpb`), `uvx`, or `pip`
 
 **Two operating modes:**
@@ -187,10 +187,12 @@ Create a tag called "Business Expenses" in red
 | `get_transactions_summary` | Aggregate transaction stats | read |
 | `get_transaction_splits` | Get split information | read |
 | `get_recurring_transactions` | Get recurring transactions | read |
+| `find_merchant_id_by_name` | Search recent transactions for a merchant and return distinct IDs | read |
 | `create_transaction` | Create new transaction | write |
 | `update_transaction` | Update existing transaction | write |
 | `delete_transaction` | Delete a transaction | write |
 | `update_transaction_splits` | Create/modify/delete splits | write |
+| `update_recurring_merchant` | Mark/unmark a merchant as recurring, update its frequency/amount, or deactivate it (requires `--enable-write`) | write |
 | **Tags** | | |
 | `get_transaction_tags` | Get all tags | read |
 | `create_transaction_tag` | Create new tag | write |

--- a/src/monarch_mcp/server.py
+++ b/src/monarch_mcp/server.py
@@ -1061,7 +1061,7 @@ async def find_merchant_id_by_name(
 async def update_recurring_merchant(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     merchant_id: str,
     name: str,
-    is_recurring: Optional[bool] = None,
+    is_recurring: bool,
     frequency: Optional[str] = None,
     base_date: Optional[str] = None,
     amount: Optional[float] = None,
@@ -1071,22 +1071,31 @@ async def update_recurring_merchant(  # pylint: disable=too-many-arguments,too-m
 
     The Monarch UI's "recurring transactions" list is backed by a
     per-merchant ``recurringTransactionStream``.  This tool wraps the
-    library's ``update_reoccuring`` mutation so callers can:
+    library's ``update_reoccuring`` mutation.  ``is_recurring`` is
+    **required** on every call: Monarch rejects a recurrence change that
+    doesn't state it, so it must always be passed.
 
-    - mark a merchant as recurring (``is_recurring=True``) and set its
-      frequency / base date / amount,
-    - update an existing recurrence's amount or schedule,
-    - deactivate a stale recurrence (``is_active=False``) — the entry
-      stays in the merchant record but stops surfacing as a bill,
-    - clear the recurring flag entirely (``is_recurring=False``).
+    - **Mark recurring / set the full schedule** — ``is_recurring=True``
+      with ``frequency`` / ``base_date`` / ``amount``.
+    - **Adjust an existing recurrence** (change the amount, or switch it
+      on/off) — keep ``is_recurring=True`` and pass only the field you are
+      changing; Monarch keeps the rest of the schedule. Omitting
+      ``is_recurring`` here is what produced the opaque
+      "Something went wrong" error, hence it is now mandatory.
+    - **Deactivate without deleting** — ``is_recurring=True,
+      is_active=False`` keeps the recurrence defined but stops surfacing it
+      as a bill.
+    - **Clear the recurring flag entirely** — ``is_recurring=False``.
 
     Args:
         merchant_id: Monarch merchant ID (use ``find_merchant_id_by_name``).
         name: Merchant display name (required by Monarch's mutation).
-        is_recurring: True to mark recurring, False to unmark.
+        is_recurring: Required. True to mark/keep recurring, False to unmark.
         frequency: Recurrence cadence — e.g. ``monthly``, ``weekly``,
-            ``biweekly``, ``yearly``.
-        base_date: Recurrence anchor date in YYYY-MM-DD format.
+            ``biweekly``, ``yearly``. Optional when adjusting an existing
+            recurrence (Monarch keeps the current cadence).
+        base_date: Recurrence anchor date in YYYY-MM-DD format. Optional
+            when adjusting an existing recurrence.
         amount: Expected recurring amount (negative for expenses).
         is_active: True to surface as an upcoming bill; False to keep
             the recurrence definition but stop showing it.

--- a/src/monarch_mcp/server.py
+++ b/src/monarch_mcp/server.py
@@ -1014,6 +1014,101 @@ async def get_recurring_transactions(
 
 
 @mcp.tool()
+@_handle_mcp_errors("finding merchant id by name")
+async def find_merchant_id_by_name(
+    name: str,
+    limit: int = 5,
+) -> str:
+    """Find merchant IDs by (partial) name.
+
+    Searches recent transactions matching ``name`` and returns the
+    distinct merchants seen, with their IDs.  Useful before calling
+    ``update_recurring_merchant``: Monarch's mutation operates on a
+    merchant, not a name, so you need the ID.
+
+    Args:
+        name: Free-text search query (matched against merchant + description).
+        limit: Maximum number of distinct merchants to return.
+    """
+
+    async def _search() -> Dict[str, Any]:
+        client = await _get_monarch_client()
+        return await client.get_transactions(search=name, limit=200)
+
+    result = await with_auth_recovery(_search())
+    seen: Dict[str, Dict[str, Any]] = {}
+    for txn in result.get("allTransactions", {}).get("results", []):
+        merchant = txn.get("merchant") or {}
+        mid = merchant.get("id")
+        mname = merchant.get("name")
+        if not mid:
+            continue
+        if mid not in seen:
+            seen[mid] = {
+                "merchant_id": mid,
+                "merchant_name": mname,
+                "sample_amount": txn.get("amount"),
+                "sample_date": txn.get("date"),
+                "sample_account": (txn.get("account") or {}).get("displayName"),
+            }
+        if len(seen) >= limit:
+            break
+    return json.dumps(list(seen.values()), indent=2, default=str)
+
+
+@mcp.tool(enabled=_WRITE_ENABLED)
+@_handle_mcp_errors("updating recurring merchant")
+async def update_recurring_merchant(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+    merchant_id: str,
+    name: str,
+    is_recurring: Optional[bool] = None,
+    frequency: Optional[str] = None,
+    base_date: Optional[str] = None,
+    amount: Optional[float] = None,
+    is_active: Optional[bool] = None,
+) -> str:
+    """Update or create the recurring-merchant settings for a merchant.
+
+    The Monarch UI's "recurring transactions" list is backed by a
+    per-merchant ``recurringTransactionStream``.  This tool wraps the
+    library's ``update_reoccuring`` mutation so callers can:
+
+    - mark a merchant as recurring (``is_recurring=True``) and set its
+      frequency / base date / amount,
+    - update an existing recurrence's amount or schedule,
+    - deactivate a stale recurrence (``is_active=False``) — the entry
+      stays in the merchant record but stops surfacing as a bill,
+    - clear the recurring flag entirely (``is_recurring=False``).
+
+    Args:
+        merchant_id: Monarch merchant ID (use ``find_merchant_id_by_name``).
+        name: Merchant display name (required by Monarch's mutation).
+        is_recurring: True to mark recurring, False to unmark.
+        frequency: Recurrence cadence — e.g. ``monthly``, ``weekly``,
+            ``biweekly``, ``yearly``.
+        base_date: Recurrence anchor date in YYYY-MM-DD format.
+        amount: Expected recurring amount (negative for expenses).
+        is_active: True to surface as an upcoming bill; False to keep
+            the recurrence definition but stop showing it.
+    """
+
+    async def _update() -> Dict[str, Any]:
+        client = await _get_monarch_client()
+        return await client.update_reoccuring(
+            merchant_id=merchant_id,
+            name=name,
+            is_recurring=is_recurring,
+            frequency=frequency,
+            base_date=base_date,
+            amount=amount,
+            is_active=is_active,
+        )
+
+    result = await with_auth_recovery(_update())
+    return json.dumps(result, indent=2, default=str)
+
+
+@mcp.tool()
 @_handle_mcp_errors("getting transactions summary")
 async def get_transactions_summary() -> str:
     """Get aggregate transaction summary (count, sum, avg, max, income, expenses)."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,7 @@ WRITE_TOOL_NAMES = frozenset({
     "create_transaction_category", "delete_transaction_category",
     "create_manual_account", "update_account", "delete_account",
     "create_transaction_rule", "delete_transaction_rule",
+    "update_recurring_merchant",
 })
 
 

--- a/tests/integration/test_recurring_merchant_live.py
+++ b/tests/integration/test_recurring_merchant_live.py
@@ -2,15 +2,24 @@
 
 ``find_merchant_id_by_name`` is a read tool, so its distinct-merchant / limit /
 empty-result behaviour is exercised directly against the live API. The write tool
-``update_recurring_merchant`` is exercised only on its **invalid-id error path** —
-a real merchant's recurring schedule has no ``MCP-Test-`` handle to clean up, so the
-suite never mutates one (that happy-path flow lives in the agent skill's Phase 14).
+``update_recurring_merchant`` is exercised on its **invalid-id error path** and on a
+**self-restoring partial-edit round-trip** (mark recurring → switch off → re-price →
+clear). The round-trip only ever touches a merchant that is *not already recurring*
+and restores it to non-recurring in a ``finally`` block, so a real bill is never left
+mutated — this is the regression guard for the bug where a partial edit that omitted
+``is_recurring`` was rejected by Monarch with an opaque error.
 """
 # pylint: disable=missing-function-docstring,redefined-outer-name
 
 import pytest
 
 pytestmark = pytest.mark.integration
+
+# Wide window so an existing recurrence (even off-cycle) is detected before we pick a
+# merchant to mutate — get_recurring_transactions is date-bound, so a narrow range
+# could miss a real bill and risk clobbering it.
+_RECURRING_SCAN_START = "2025-01-01"
+_RECURRING_SCAN_END = "2026-12-31"
 
 
 @pytest.fixture
@@ -22,6 +31,42 @@ async def a_merchant_name(live_mcp_client, call_json):
         if name:
             return name
     pytest.skip("live account has no transactions with a merchant to search for")
+
+
+@pytest.fixture
+async def non_recurring_merchant(live_write_client, call_json):
+    """A real merchant that is NOT currently recurring, as ``(id, name)``.
+
+    Mutating an already-recurring merchant would risk the user's real bill, so we
+    pick one absent from the (wide-window) recurring list and the test restores it to
+    non-recurring afterwards. Skips if the account has no safe candidate.
+    """
+    recurring = await call_json(
+        live_write_client,
+        "get_recurring_transactions",
+        {"start_date": _RECURRING_SCAN_START, "end_date": _RECURRING_SCAN_END},
+    )
+    items = recurring.get("recurringTransactionItems", []) if isinstance(recurring, dict) else []
+    recurring_ids = {
+        ((item.get("stream") or {}).get("merchant") or {}).get("id") for item in items
+    }
+
+    txns = await call_json(live_write_client, "get_transactions", {"limit": 50})
+    seen_names = []
+    for txn in txns:
+        name = txn.get("merchant")
+        if name and name not in seen_names:
+            seen_names.append(name)
+
+    for name in seen_names:
+        merchants = await call_json(
+            live_write_client, "find_merchant_id_by_name", {"name": name, "limit": 5}
+        )
+        for merchant in merchants:
+            mid = merchant.get("merchant_id")
+            if mid and mid not in recurring_ids:
+                return mid, merchant.get("merchant_name") or name
+    pytest.skip("live account has no non-recurring merchant to safely mutate")
 
 
 async def test_find_merchant_id_by_name_distinct(live_mcp_client, call_json, a_merchant_name):
@@ -72,3 +117,55 @@ async def test_update_recurring_merchant_invalid_id_is_graceful(
     assert "Traceback" not in text, text[:300]
     data = maybe_json(text)
     assert text.startswith("Error ") or isinstance(data, (dict, list)), text[:300]
+
+
+async def test_update_recurring_merchant_partial_edits_round_trip(
+    live_write_client, call_json, non_recurring_merchant
+):
+    """Mark recurring → switch off → re-price → clear, restoring the merchant.
+
+    The switch-off and re-price steps are partial edits: they pass only the field
+    being changed plus the now-mandatory ``is_recurring=True``. Before the fix these
+    omitted ``is_recurring`` and Monarch rejected them with an opaque error.
+    """
+    merchant_id, merchant_name = non_recurring_merchant
+    base = {"merchant_id": merchant_id, "name": merchant_name}
+
+    try:
+        full = await call_json(
+            live_write_client,
+            "update_recurring_merchant",
+            {**base, "is_recurring": True, "frequency": "monthly",
+             "base_date": "2025-01-15", "amount": -9.99, "is_active": True},
+        )
+        stream = full["updateMerchant"]["merchant"]["recurringTransactionStream"]
+        assert stream is not None, full
+        assert stream["isActive"] is True
+        assert stream["amount"] == pytest.approx(-9.99)
+
+        # Partial edit #1 — switch the bill off; Monarch keeps the schedule.
+        off = await call_json(
+            live_write_client,
+            "update_recurring_merchant",
+            {**base, "is_recurring": True, "is_active": False},
+        )
+        assert off["updateMerchant"]["errors"] is None, off
+        assert off["updateMerchant"]["merchant"]["recurringTransactionStream"]["isActive"] is False
+
+        # Partial edit #2 — change just the amount (and switch back on).
+        repriced = await call_json(
+            live_write_client,
+            "update_recurring_merchant",
+            {**base, "is_recurring": True, "is_active": True, "amount": -12.49},
+        )
+        stream = repriced["updateMerchant"]["merchant"]["recurringTransactionStream"]
+        assert stream["amount"] == pytest.approx(-12.49)
+        assert stream["isActive"] is True
+    finally:
+        # Restore: clear the recurring flag so the merchant is non-recurring again.
+        cleared = await call_json(
+            live_write_client,
+            "update_recurring_merchant",
+            {**base, "is_recurring": False},
+        )
+        assert cleared["updateMerchant"]["merchant"]["recurringTransactionStream"] is None

--- a/tests/integration/test_recurring_merchant_live.py
+++ b/tests/integration/test_recurring_merchant_live.py
@@ -1,0 +1,74 @@
+"""Live e2e tests for recurring-merchant tools — read-tool edges + live error paths.
+
+``find_merchant_id_by_name`` is a read tool, so its distinct-merchant / limit /
+empty-result behaviour is exercised directly against the live API. The write tool
+``update_recurring_merchant`` is exercised only on its **invalid-id error path** —
+a real merchant's recurring schedule has no ``MCP-Test-`` handle to clean up, so the
+suite never mutates one (that happy-path flow lives in the agent skill's Phase 14).
+"""
+# pylint: disable=missing-function-docstring,redefined-outer-name
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def a_merchant_name(live_mcp_client, call_json):
+    """A merchant name pulled from recent transactions (skip if the account has none)."""
+    txns = await call_json(live_mcp_client, "get_transactions", {"limit": 50})
+    for txn in txns:
+        name = txn.get("merchant")
+        if name:
+            return name
+    pytest.skip("live account has no transactions with a merchant to search for")
+
+
+async def test_find_merchant_id_by_name_distinct(live_mcp_client, call_json, a_merchant_name):
+    merchants = await call_json(
+        live_mcp_client, "find_merchant_id_by_name", {"name": a_merchant_name}
+    )
+    assert isinstance(merchants, list)
+    assert merchants, f"no merchants found for a name taken from a real txn: {a_merchant_name!r}"
+    ids = [m["merchant_id"] for m in merchants]
+    assert all(ids), merchants               # every entry carries a non-empty merchant_id
+    assert len(ids) == len(set(ids)), ids    # ids are distinct (deduped by the tool)
+
+
+async def test_find_merchant_id_by_name_respects_limit(
+    live_mcp_client, call_json, a_merchant_name
+):
+    merchants = await call_json(
+        live_mcp_client, "find_merchant_id_by_name", {"name": a_merchant_name, "limit": 1}
+    )
+    assert isinstance(merchants, list)
+    assert len(merchants) <= 1
+
+
+async def test_find_merchant_id_by_name_empty_for_nonsense(live_mcp_client, call_json):
+    merchants = await call_json(
+        live_mcp_client,
+        "find_merchant_id_by_name",
+        {"name": "zzzz-no-such-merchant-zzzz-MCP-Test"},
+    )
+    assert merchants == []
+
+
+async def test_update_recurring_merchant_invalid_id_is_graceful(
+    live_write_client, call_text, maybe_json
+):
+    text = await call_text(
+        live_write_client,
+        "update_recurring_merchant",
+        {
+            "merchant_id": "000000000000000000",
+            "name": "MCP-Test-NoSuchMerchant",
+            "is_recurring": False,
+        },
+    )
+    # Robustness contract: a bogus merchant id must not leak a raw traceback. The tool
+    # returns either a decorator "Error ..." string or a parseable JSON payload (a
+    # rejection dict, or a benign object if Monarch no-ops the unknown id).
+    assert "Traceback" not in text, text[:300]
+    data = maybe_json(text)
+    assert text.startswith("Error ") or isinstance(data, (dict, list)), text[:300]

--- a/tests/test_recurring_merchant.py
+++ b/tests/test_recurring_merchant.py
@@ -3,6 +3,9 @@
 
 import json
 
+import pytest
+from fastmcp.exceptions import ToolError
+
 
 SAMPLE_TRANSACTIONS = {
     "allTransactions": {
@@ -125,11 +128,15 @@ async def test_update_recurring_merchant_deactivate(mcp_write_client, mock_monar
         "updateMerchant": {"merchant": {"id": "m-2", "name": "OldSub"}, "errors": None}
     }
 
+    # Switching a bill off is a partial edit, but ``is_recurring`` must still be
+    # stated — Monarch rejects a recurrence change that omits it. The unchanged
+    # schedule fields stay None and Monarch keeps the existing stream values.
     await mcp_write_client.call_tool(
         "update_recurring_merchant",
         {
             "merchant_id": "m-2",
             "name": "OldSub",
+            "is_recurring": True,
             "is_active": False,
         },
     )
@@ -137,12 +144,24 @@ async def test_update_recurring_merchant_deactivate(mcp_write_client, mock_monar
     mock_monarch_client.update_reoccuring.assert_called_once_with(
         merchant_id="m-2",
         name="OldSub",
-        is_recurring=None,
+        is_recurring=True,
         frequency=None,
         base_date=None,
         amount=None,
         is_active=False,
     )
+
+
+async def test_update_recurring_merchant_requires_is_recurring(mcp_write_client, mock_monarch_client):
+    # ``is_recurring`` is mandatory: Monarch rejects any recurrence change that
+    # omits it, so the tool surfaces a missing-argument error before any call.
+    with pytest.raises(ToolError, match="is_recurring"):
+        await mcp_write_client.call_tool(
+            "update_recurring_merchant",
+            {"merchant_id": "m-2", "name": "OldSub", "is_active": False},
+        )
+
+    mock_monarch_client.update_reoccuring.assert_not_called()
 
 
 async def test_update_recurring_merchant_disabled_in_read_only(mcp_client, mock_monarch_client):  # pylint: disable=unused-argument

--- a/tests/test_recurring_merchant.py
+++ b/tests/test_recurring_merchant.py
@@ -1,0 +1,150 @@
+"""Tests for find_merchant_id_by_name and update_recurring_merchant."""
+# pylint: disable=missing-function-docstring
+
+import json
+
+
+SAMPLE_TRANSACTIONS = {
+    "allTransactions": {
+        "results": [
+            {
+                "id": "txn-1",
+                "amount": -15.99,
+                "date": "2026-04-15",
+                "merchant": {"id": "m-netflix", "name": "Netflix"},
+                "account": {"displayName": "Visa Card"},
+            },
+            {
+                "id": "txn-2",
+                "amount": -15.99,
+                "date": "2026-03-15",
+                "merchant": {"id": "m-netflix", "name": "Netflix"},
+                "account": {"displayName": "Visa Card"},
+            },
+            {
+                "id": "txn-3",
+                "amount": -29.00,
+                "date": "2026-02-10",
+                "merchant": {"id": "m-other", "name": "Netflix DVD"},
+                "account": {"displayName": "Visa Card"},
+            },
+        ]
+    }
+}
+
+
+async def test_find_merchant_id_returns_distinct(mcp_client, mock_monarch_client):
+    mock_monarch_client.get_transactions.return_value = SAMPLE_TRANSACTIONS
+
+    result = json.loads(
+        (await mcp_client.call_tool(
+            "find_merchant_id_by_name",
+            {"name": "Netflix"},
+        )).content[0].text
+    )
+
+    ids = [r["merchant_id"] for r in result]
+    assert ids == ["m-netflix", "m-other"]
+    mock_monarch_client.get_transactions.assert_called_once_with(
+        search="Netflix", limit=200,
+    )
+
+
+async def test_find_merchant_id_respects_limit(mcp_client, mock_monarch_client):
+    mock_monarch_client.get_transactions.return_value = SAMPLE_TRANSACTIONS
+
+    result = json.loads(
+        (await mcp_client.call_tool(
+            "find_merchant_id_by_name",
+            {"name": "Netflix", "limit": 1},
+        )).content[0].text
+    )
+
+    assert len(result) == 1
+    assert result[0]["merchant_id"] == "m-netflix"
+
+
+async def test_find_merchant_id_skips_blank(mcp_client, mock_monarch_client):
+    mock_monarch_client.get_transactions.return_value = {
+        "allTransactions": {
+            "results": [
+                {"id": "x", "merchant": {}, "amount": 0, "date": "2026-04-01"},
+                {"id": "y", "merchant": {"id": "m-z", "name": "Z"},
+                 "amount": -1, "date": "2026-04-02"},
+            ]
+        }
+    }
+
+    result = json.loads(
+        (await mcp_client.call_tool(
+            "find_merchant_id_by_name", {"name": "anything"},
+        )).content[0].text
+    )
+
+    assert len(result) == 1
+    assert result[0]["merchant_id"] == "m-z"
+
+
+async def test_update_recurring_merchant_passes_args(mcp_write_client, mock_monarch_client):
+    mock_monarch_client.update_reoccuring.return_value = {
+        "updateMerchant": {
+            "merchant": {"id": "m-1", "name": "Netflix"},
+            "errors": None,
+        }
+    }
+
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "update_recurring_merchant",
+            {
+                "merchant_id": "m-1",
+                "name": "Netflix",
+                "is_recurring": True,
+                "frequency": "monthly",
+                "base_date": "2026-01-15",
+                "amount": -15.99,
+                "is_active": True,
+            },
+        )).content[0].text
+    )
+
+    assert result["updateMerchant"]["merchant"]["id"] == "m-1"
+    mock_monarch_client.update_reoccuring.assert_called_once_with(
+        merchant_id="m-1",
+        name="Netflix",
+        is_recurring=True,
+        frequency="monthly",
+        base_date="2026-01-15",
+        amount=-15.99,
+        is_active=True,
+    )
+
+
+async def test_update_recurring_merchant_deactivate(mcp_write_client, mock_monarch_client):
+    mock_monarch_client.update_reoccuring.return_value = {
+        "updateMerchant": {"merchant": {"id": "m-2", "name": "OldSub"}, "errors": None}
+    }
+
+    await mcp_write_client.call_tool(
+        "update_recurring_merchant",
+        {
+            "merchant_id": "m-2",
+            "name": "OldSub",
+            "is_active": False,
+        },
+    )
+
+    mock_monarch_client.update_reoccuring.assert_called_once_with(
+        merchant_id="m-2",
+        name="OldSub",
+        is_recurring=None,
+        frequency=None,
+        base_date=None,
+        amount=None,
+        is_active=False,
+    )
+
+
+async def test_update_recurring_merchant_disabled_in_read_only(mcp_client, mock_monarch_client):  # pylint: disable=unused-argument
+    tools = [t.name for t in (await mcp_client.list_tools())]
+    assert "update_recurring_merchant" not in tools


### PR DESCRIPTION
## Summary

The server already exposes `get_recurring_transactions`, but there was no way for an MCP client to **mutate** the recurring-merchant list — so the only flow was "look at the list, then go to the Monarch UI to fix it". This PR closes that gap.

Two new tools are added in `src/monarch_mcp/server.py`, between `get_recurring_transactions` and `get_transactions_summary`:

- **`find_merchant_id_by_name(name, limit=5)`** — read tool. Searches recent transactions for `name` and returns up to `limit` distinct merchants with their IDs (plus a sample amount/date/account). Needed because Monarch's recurring mutation operates on a merchant ID, not a name.
- **`update_recurring_merchant(merchant_id, name, is_recurring=None, frequency=None, base_date=None, amount=None, is_active=None)`** — write tool, gated by `_WRITE_ENABLED` (`--enable-write`). Wraps `client.update_reoccuring()` from the `monarchmoneycommunity` library (the typo "reoccuring" is upstream — not ours). Lets a client mark/unmark a merchant as recurring, update frequency/base_date/amount, or activate/deactivate the recurrence definition.

## Use case

Audit-driven recurrence cleanup, all from inside an MCP conversation:

- **REMOVE** — "list my recurring bills, then deactivate Hulu" → `get_recurring_transactions` -> `find_merchant_id_by_name("Hulu")` -> `update_recurring_merchant(merchant_id=..., name="Hulu", is_active=False)`.
- **ADD** — "Spotify shows up every month but isn't flagged as recurring; mark it" → `find_merchant_id_by_name("Spotify")` -> `update_recurring_merchant(..., is_recurring=True, frequency="monthly", base_date=..., amount=-9.99)`.
- **UPDATE** — "my Netflix bill went from 15.99 to 22.99" → `update_recurring_merchant(merchant_id, name, amount=-22.99)`.

The read tool is available in both modes; the write tool only appears when the server is started with `--enable-write` (the existing safety gate).

## Implementation notes

- No new dependencies. `monarchmoneycommunity==1.3.1` was already pinned on `main`, and `update_reoccuring` ships with that version.
- `tests/conftest.py` adds `update_recurring_merchant` to `WRITE_TOOL_NAMES` so the write-mode fixture flips it on for the relevant tests.
- `update_recurring_merchant` carries `# pylint: disable=too-many-arguments,too-many-positional-arguments` to match the project style for similar wide-signature tools (`create_transaction`, `update_transaction`, etc.).
- README updated (tool count and tool table, including the `--enable-write` note).
- `.claude/skills/test-monarch-mcp/` updated: SKILL.md gains a Phase 13 (Recurring Merchant Management) and a matching cleanup step that restores the merchant's prior recurring state; `references/read-only-tools.md` gets three `find_merchant_id_by_name` cases; `references/recurring-merchant.md` is new.

## Test plan

- [x] `pytest tests/` — 246 tests pass (240 baseline + 6 new in `tests/test_recurring_merchant.py`).
- [x] `pylint src/monarch_mcp/` — 10.00/10.
- [x] `find_merchant_id_by_name` returns distinct merchants (no duplicate IDs) and respects `limit`.
- [x] `update_recurring_merchant` is hidden when the server runs without `--enable-write` (verified by `test_update_recurring_merchant_disabled_in_read_only`).
- [x] Deactivation flow works end-to-end with positional defaults (`is_recurring=None`, `frequency=None`, `base_date=None`, `amount=None`, `is_active=False` is forwarded to `client.update_reoccuring`).
- [x] Live smoke against a real Monarch account via the test skill's Phase 13 (manual, optional — reviewer's call).