### PR TITLE
fix(auth): harden loopback login server (CSRF, DNS-rebinding, info-hygiene)

### DIFF
--- a/src/monarch_mcp/auth_server.py
+++ b/src/monarch_mcp/auth_server.py
@@ -224,11 +224,49 @@ class _AuthHandler(BaseHTTPRequestHandler):
 
     # Attached by the factory before the server starts
     auth_state: _AuthState
+    expected_port: int
+
+    # ── Request guards (CSRF / DNS-rebinding hardening) ──
+
+    def _allowed_hosts(self) -> set[str]:
+        """Host header values that correspond to this loopback server."""
+        return {
+            f"127.0.0.1:{self.expected_port}",
+            f"localhost:{self.expected_port}",
+        }
+
+    def _allowed_origins(self) -> set[str]:
+        """Origin header values permitted to call the auth endpoints."""
+        return {
+            f"http://127.0.0.1:{self.expected_port}",
+            f"http://localhost:{self.expected_port}",
+        }
+
+    def _is_trusted_request(self) -> bool:
+        """Reject DNS-rebinding (foreign Host) and cross-origin requests.
+
+        This server only ever talks to a same-origin page it served itself
+        on ``http://127.0.0.1:<port>``.  Enforcing the Host header blocks
+        DNS-rebinding attacks; enforcing the Origin header (when present)
+        blocks cross-site requests.
+        """
+        host = self.headers.get("Host", "")
+        if host not in self._allowed_hosts():
+            logger.warning("Rejected request with unexpected Host header: %r", host)
+            return False
+        origin = self.headers.get("Origin")
+        if origin is not None and origin not in self._allowed_origins():
+            logger.warning("Rejected cross-origin request (Origin: %r)", origin)
+            return False
+        return True
 
     # ── GET ──
 
     def do_GET(self):  # pylint: disable=invalid-name
         """Serve the login page for GET /."""
+        if not self._is_trusted_request():
+            self.send_error(403)
+            return
         if self.path == "/":
             self._send_html(_LOGIN_PAGE)
         else:
@@ -238,6 +276,20 @@ class _AuthHandler(BaseHTTPRequestHandler):
 
     def do_POST(self):  # pylint: disable=invalid-name
         """Handle POST requests for /login and /mfa."""
+        if not self._is_trusted_request():
+            self.send_error(403)
+            return
+
+        # Require an application/json body.  A cross-site fetch can only set
+        # this Content-Type by triggering a CORS preflight, which this server
+        # (sending no Access-Control-* headers) will fail — closing the
+        # login-CSRF vector that CORS-"simple" content types would leave open.
+        content_type = self.headers.get("Content-Type", "").split(";", 1)[0].strip().lower()
+        if content_type != "application/json":
+            logger.warning("Rejected POST with non-JSON Content-Type: %r", content_type)
+            self.send_error(403)
+            return
+
         try:
             length = int(self.headers.get("Content-Length", 0))
             body = self.rfile.read(length).decode()
@@ -281,7 +333,7 @@ class _AuthHandler(BaseHTTPRequestHandler):
             self._send_json({"mfa_required": True})
 
         except LoginFailedException:
-            logger.error("Login failed for %s: invalid credentials", email)
+            logger.error("Login failed: invalid credentials")
             self._send_json({"error": "Invalid email or password."})
 
         except TransportServerError as exc:
@@ -293,7 +345,9 @@ class _AuthHandler(BaseHTTPRequestHandler):
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.error("Unexpected error during login: %s", exc)
-            self._send_json({"error": f"Login failed: {exc}"})
+            self._send_json(
+                {"error": "Login failed due to an unexpected error. Please try again."}
+            )
 
     def _handle_mfa(self, data: dict):
         """Verify the MFA code and complete authentication."""
@@ -335,7 +389,9 @@ class _AuthHandler(BaseHTTPRequestHandler):
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.error("Unexpected error during MFA: %s", exc)
-            self._send_json({"error": f"MFA verification failed: {exc}"})
+            self._send_json(
+                {"error": "MFA verification failed due to an unexpected error. Please try again."}
+            )
 
     # ── Response helpers ──
 
@@ -424,11 +480,11 @@ def trigger_auth_flow() -> None:
     port = _find_free_port()
     state = _AuthState()
 
-    # Create a handler class that carries our state
+    # Create a handler class that carries our state and expected port
     handler_class = type(
         "_BoundAuthHandler",
         (_AuthHandler,),
-        {"auth_state": state},
+        {"auth_state": state, "expected_port": port},
     )
 
     server = HTTPServer(("127.0.0.1", port), handler_class)

--- a/src/monarch_mcp/auth_server.py
+++ b/src/monarch_mcp/auth_server.py
@@ -32,6 +32,18 @@ _AUTH_TIMEOUT = 600  # 10 minutes
 _auth_lock = threading.Lock()
 _auth_guard: dict[str, bool] = {"active": False}
 
+# Generic client-facing messages for unexpected errors. The real exception is
+# written to the server log (stderr) only; we deliberately do not echo it to the
+# browser (CWE-209), but we point the operator to where the detail lives.
+_LOGIN_ERROR_MESSAGE = (
+    "Login failed due to an unexpected error. "
+    "Please try again, or check the server logs for details."
+)
+_MFA_ERROR_MESSAGE = (
+    "MFA verification failed due to an unexpected error. "
+    "Please try again, or check the server logs for details."
+)
+
 # ── HTML served to the browser ──────────────────────────────────────────
 
 _LOGIN_PAGE = """\
@@ -345,9 +357,7 @@ class _AuthHandler(BaseHTTPRequestHandler):
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.error("Unexpected error during login: %s", exc)
-            self._send_json(
-                {"error": "Login failed due to an unexpected error. Please try again."}
-            )
+            self._send_json({"error": _LOGIN_ERROR_MESSAGE})
 
     def _handle_mfa(self, data: dict):
         """Verify the MFA code and complete authentication."""
@@ -389,9 +399,7 @@ class _AuthHandler(BaseHTTPRequestHandler):
 
         except Exception as exc:  # pylint: disable=broad-exception-caught
             logger.error("Unexpected error during MFA: %s", exc)
-            self._send_json(
-                {"error": "MFA verification failed due to an unexpected error. Please try again."}
-            )
+            self._send_json({"error": _MFA_ERROR_MESSAGE})
 
     # ── Response helpers ──
 

--- a/src/monarch_mcp/auth_server.py
+++ b/src/monarch_mcp/auth_server.py
@@ -230,6 +230,17 @@ class _AuthState:
     awaiting_mfa: bool = False
     completed: bool = False
 
+    def clear_secrets(self) -> None:
+        """Drop the cached credentials once they are no longer needed.
+
+        The password is cached only to span the MFA challenge; scrub it (and
+        the email) as soon as auth completes or the server shuts down so it
+        does not linger in memory for the lifetime of the process.
+        """
+        self.email = ""
+        self.password = ""
+        self.awaiting_mfa = False
+
 
 class _AuthHandler(BaseHTTPRequestHandler):
     """HTTP handler that serves the login page and processes auth requests."""
@@ -383,6 +394,7 @@ class _AuthHandler(BaseHTTPRequestHandler):
 
             secure_session.save_authenticated_session(mm)
             self.auth_state.completed = True
+            self.auth_state.clear_secrets()
             logger.info("Browser authentication successful (with MFA)")
             self._send_json({"success": True})
 
@@ -514,6 +526,7 @@ def trigger_auth_flow() -> None:
             if state.completed:
                 logger.info("Auth server stopped — authentication complete")
         finally:
+            state.clear_secrets()
             with _auth_lock:
                 _auth_guard["active"] = False
 

--- a/src/monarch_mcp/server.py
+++ b/src/monarch_mcp/server.py
@@ -8,7 +8,6 @@ import json
 import logging
 import os
 import re
-import traceback
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -199,9 +198,8 @@ def check_auth_status() -> str:
         else:
             status = "No authentication token found in keyring\n"
 
-        email = os.getenv("MONARCH_EMAIL")
-        if email:
-            status += f"Environment email: {email}\n"
+        if os.getenv("MONARCH_EMAIL"):
+            status += "Environment credentials configured: yes\n"
 
         status += (
             "\nTry get_accounts to test connection or run login_setup.py if needed."
@@ -219,14 +217,11 @@ def debug_session_loading() -> str:
         # Check keyring access
         token = secure_session.load_token()
         if token:
-            return f"Token found in keyring (length: {len(token)})"
+            return "Token found in keyring."
         return "No token found in keyring. Run login_setup.py to authenticate."
     except Exception as e:  # pylint: disable=broad-exception-caught
-        error_details = traceback.format_exc()
-        return (
-            f"Keyring access failed:\nError: {e}\n"
-            f"Type: {type(e)}\nTraceback:\n{error_details}"
-        )
+        logger.error("Keyring access failed: %s", e, exc_info=True)
+        return "Keyring access failed. See the server logs for details."
 
 
 @mcp.tool()

--- a/tests/test_auth_handler.py
+++ b/tests/test_auth_handler.py
@@ -454,6 +454,8 @@ def test_login_unexpected_error_returns_generic_message():
     resp = handler._send_json.call_args[0][0]
     assert "error" in resp
     assert "internal stack detail xyz" not in resp["error"]
+    # Points the operator to where the real detail lives, without leaking it.
+    assert "logs" in resp["error"].lower()
 
 
 def test_mfa_unexpected_error_returns_generic_message():
@@ -474,6 +476,8 @@ def test_mfa_unexpected_error_returns_generic_message():
     resp = handler._send_json.call_args[0][0]
     assert "error" in resp
     assert "internal stack detail xyz" not in resp["error"]
+    # Points the operator to where the real detail lives, without leaking it.
+    assert "logs" in resp["error"].lower()
 
 
 # ===================================================================

--- a/tests/test_auth_handler.py
+++ b/tests/test_auth_handler.py
@@ -24,10 +24,25 @@ from monarch_mcp.auth_server import (
 # ── Handler factory ───────────────────────────────────────────────
 
 
-def _make_handler(path="/", method="GET", body=None):
-    """Create an _AuthHandler wired for unit testing without sockets."""
+def _make_handler(
+    path="/",
+    method="GET",
+    body=None,
+    *,
+    expected_port=8080,
+    content_type="application/json",
+    host="127.0.0.1:8080",
+    origin="http://127.0.0.1:8080",
+):
+    """Create an _AuthHandler wired for unit testing without sockets.
+
+    Defaults produce a same-origin, JSON request that passes the
+    Host/Origin/Content-Type guards.  Pass ``None`` for ``content_type``,
+    ``host``, or ``origin`` to omit that header.
+    """
     handler = object.__new__(_AuthHandler)
     handler.auth_state = _AuthState()
+    handler.expected_port = expected_port
     handler.path = path
 
     # Wire up the response plumbing
@@ -41,10 +56,19 @@ def _make_handler(path="/", method="GET", body=None):
     if body is not None:
         raw = json.dumps(body).encode() if isinstance(body, dict) else body
         handler.rfile = io.BytesIO(raw)
-        handler.headers = {"Content-Length": str(len(raw))}
+        content_length = str(len(raw))
     else:
         handler.rfile = io.BytesIO(b"")
-        handler.headers = {"Content-Length": "0"}
+        content_length = "0"
+
+    headers = {"Content-Length": content_length}
+    if content_type is not None:
+        headers["Content-Type"] = content_type
+    if host is not None:
+        headers["Host"] = host
+    if origin is not None:
+        headers["Origin"] = origin
+    handler.headers = headers
 
     return handler
 
@@ -264,7 +288,12 @@ def test_do_post_unknown_route():
 def test_do_post_invalid_json():
     handler = _make_handler(path="/login")
     handler.rfile = io.BytesIO(b"not-json{{{")
-    handler.headers = {"Content-Length": "11"}
+    handler.headers = {
+        "Content-Length": "11",
+        "Content-Type": "application/json",
+        "Host": "127.0.0.1:8080",
+        "Origin": "http://127.0.0.1:8080",
+    }
     handler._send_json = Mock()
 
     handler.do_POST()
@@ -326,3 +355,154 @@ def test_validate_token_server_error():
         result = _validate_token("some-token")
 
     assert result is None
+
+
+# ===================================================================
+# Request-origin guards (CSRF / DNS-rebinding hardening)
+# ===================================================================
+
+
+def test_do_post_rejects_non_json_content_type():
+    # A cross-site fetch can dodge a CORS preflight by sending a "simple"
+    # Content-Type like text/plain. Such a request must be rejected before
+    # any authentication side effect (login-CSRF).
+    handler = _make_handler(
+        path="/login",
+        body={"email": "attacker@evil.com", "password": "x"},
+        content_type="text/plain",
+    )
+    handler._send_json = Mock()
+    handler._handle_login = Mock()
+    handler.do_POST()
+
+    handler.send_error.assert_called_once_with(403)
+    handler._handle_login.assert_not_called()
+
+
+def test_do_post_rejects_cross_origin():
+    handler = _make_handler(
+        path="/login",
+        body={"email": "attacker@evil.com", "password": "x"},
+        origin="https://evil.example",
+    )
+    handler._send_json = Mock()
+    handler._handle_login = Mock()
+    handler.do_POST()
+
+    handler.send_error.assert_called_once_with(403)
+    handler._handle_login.assert_not_called()
+
+
+def test_do_post_rejects_unexpected_host():
+    # DNS-rebinding: a rebound hostname that resolves to 127.0.0.1.
+    handler = _make_handler(
+        path="/login",
+        body={"email": "attacker@evil.com", "password": "x"},
+        host="attacker.example",
+    )
+    handler._send_json = Mock()
+    handler._handle_login = Mock()
+    handler.do_POST()
+
+    handler.send_error.assert_called_once_with(403)
+    handler._handle_login.assert_not_called()
+
+
+def test_do_get_rejects_unexpected_host():
+    handler = _make_handler(path="/", host="attacker.example")
+    handler._send_html = Mock()
+    handler.do_GET()
+
+    handler.send_error.assert_called_once_with(403)
+    handler._send_html.assert_not_called()
+
+
+def test_do_post_allows_request_without_origin_header():
+    # Non-browser clients (which omit Origin) on the correct loopback Host
+    # are still served, as long as Content-Type is application/json.
+    handler = _make_handler(
+        path="/login",
+        body={"email": "", "password": ""},
+        origin=None,
+    )
+    handler._send_json = Mock()
+    handler.do_POST()
+
+    handler.send_error.assert_not_called()
+    resp = handler._send_json.call_args[0][0]
+    assert "error" in resp
+    assert "required" in resp["error"].lower()
+
+
+# ===================================================================
+# Error-message hygiene (no internal details leaked to the client)
+# ===================================================================
+
+
+def test_login_unexpected_error_returns_generic_message():
+    handler = _make_handler()
+    handler._send_json = Mock()
+    with (
+        patch("monarch_mcp.auth_server.MonarchMoney"),
+        patch(
+            "monarch_mcp.auth_server._run_sync",
+            side_effect=RuntimeError("internal stack detail xyz"),
+        ),
+    ):
+        handler._handle_login({"email": "a@b.com", "password": "pass"})
+
+    resp = handler._send_json.call_args[0][0]
+    assert "error" in resp
+    assert "internal stack detail xyz" not in resp["error"]
+
+
+def test_mfa_unexpected_error_returns_generic_message():
+    handler = _make_handler()
+    handler._send_json = Mock()
+    handler.auth_state.email = "a@b.com"
+    handler.auth_state.password = "pass"
+    handler.auth_state.awaiting_mfa = True
+    with (
+        patch("monarch_mcp.auth_server.MonarchMoney"),
+        patch(
+            "monarch_mcp.auth_server._run_sync",
+            side_effect=RuntimeError("internal stack detail xyz"),
+        ),
+    ):
+        handler._handle_mfa({"code": "123456"})
+
+    resp = handler._send_json.call_args[0][0]
+    assert "error" in resp
+    assert "internal stack detail xyz" not in resp["error"]
+
+
+# ===================================================================
+# PII hygiene (account email not written to logs)
+# ===================================================================
+
+
+def test_login_failure_does_not_log_email():
+    from monarchmoney import LoginFailedException  # pylint: disable=import-outside-toplevel
+
+    handler = _make_handler()
+    handler._send_json = Mock()
+    with (
+        patch("monarch_mcp.auth_server.MonarchMoney"),
+        patch(
+            "monarch_mcp.auth_server._run_sync",
+            side_effect=LoginFailedException(),
+        ),
+        patch("monarch_mcp.auth_server.logger") as mock_log,
+    ):
+        handler._handle_login({"email": "secret@example.com", "password": "pass"})
+
+    logged = " ".join(
+        str(arg)
+        for call in (
+            mock_log.error.call_args_list
+            + mock_log.info.call_args_list
+            + mock_log.warning.call_args_list
+        )
+        for arg in call[0]
+    )
+    assert "secret@example.com" not in logged

--- a/tests/test_auth_handler.py
+++ b/tests/test_auth_handler.py
@@ -183,6 +183,35 @@ def test_mfa_success():
     assert resp["success"] is True
 
 
+def test_auth_state_clear_secrets():
+    state = _AuthState(email="a@b.com", password="pass", awaiting_mfa=True)
+    state.clear_secrets()
+
+    assert state.email == ""
+    assert state.password == ""
+    assert state.awaiting_mfa is False
+
+
+def test_mfa_success_clears_cached_credentials():
+    # The plaintext password (cached across the MFA challenge) must not
+    # linger in memory after authentication completes.
+    handler = _make_handler()
+    handler._send_json = Mock()
+    handler.auth_state.email = "a@b.com"
+    handler.auth_state.password = "pass"
+    handler.auth_state.awaiting_mfa = True
+
+    with (
+        patch("monarch_mcp.auth_server.MonarchMoney"),
+        patch("monarch_mcp.auth_server._run_sync"),
+        patch("monarch_mcp.auth_server.secure_session"),
+    ):
+        handler._handle_mfa({"code": "123456"})
+
+    assert handler.auth_state.email == ""
+    assert handler.auth_state.password == ""
+
+
 # ===================================================================
 # _send_json / _send_html
 # ===================================================================

--- a/tests/test_auth_tools.py
+++ b/tests/test_auth_tools.py
@@ -10,7 +10,8 @@ async def test_check_auth_status_with_token(mcp_client):
 async def test_debug_session_loading_with_token(mcp_client):
     result = (await mcp_client.call_tool("debug_session_loading")).content[0].text
     assert "Token found in keyring" in result
-    assert "length:" in result
+    # The token length must not be exposed (near-zero entropy, but no reason to leak).
+    assert "length:" not in result
 
 
 async def test_setup_authentication(mcp_client):

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -216,7 +216,9 @@ def test_login_handler_unexpected_error():
 
     response = handler._send_json.call_args[0][0]
     assert "error" in response
-    assert "network down" in response["error"]
+    # The raw exception text must not leak to the client (info disclosure).
+    assert "network down" not in response["error"]
+    assert "unexpected error" in response["error"].lower()
 
 
 # --- _handle_mfa ---
@@ -275,4 +277,6 @@ def test_mfa_handler_unexpected_error():
 
     response = handler._send_json.call_args[0][0]
     assert "error" in response
-    assert "timeout" in response["error"]
+    # The raw exception text must not leak to the client (info disclosure).
+    assert "timeout" not in response["error"]
+    assert "unexpected error" in response["error"].lower()

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -219,6 +219,7 @@ def test_login_handler_unexpected_error():
     # The raw exception text must not leak to the client (info disclosure).
     assert "network down" not in response["error"]
     assert "unexpected error" in response["error"].lower()
+    assert "logs" in response["error"].lower()
 
 
 # --- _handle_mfa ---
@@ -280,3 +281,4 @@ def test_mfa_handler_unexpected_error():
     # The raw exception text must not leak to the client (info disclosure).
     assert "timeout" not in response["error"]
     assert "unexpected error" in response["error"].lower()
+    assert "logs" in response["error"].lower()

--- a/tests/test_server_edge_cases.py
+++ b/tests/test_server_edge_cases.py
@@ -94,7 +94,9 @@ async def test_check_auth_with_env_email(mcp_client, monkeypatch):
     monkeypatch.setenv("MONARCH_EMAIL", "user@test.com")
     result = (await mcp_client.call_tool("check_auth_status")).content[0].text
 
-    assert "user@test.com" in result
+    # Report that env credentials are configured without echoing the address.
+    assert "Environment credentials configured" in result
+    assert "user@test.com" not in result
 
 
 async def test_check_auth_exception(mcp_client):
@@ -124,6 +126,9 @@ async def test_debug_session_exception(mcp_client):
         result = (await mcp_client.call_tool("debug_session_loading")).content[0].text
 
     assert "Keyring access failed" in result
+    # The raw exception text and traceback must not leak to the client.
+    assert "keyring busted" not in result
+    assert "Traceback" not in result
 
 
 # ===================================================================


### PR DESCRIPTION
## Summary

Closes the one confirmed vulnerability and the info-hygiene hardening items found in a security audit of the browser-based auth flow and the MCP tool surface. The temporary loopback HTTP login server (`auth_server.py`) validated no request provenance; this PR adds Host/Origin/Content-Type guards and tightens what internal detail leaks to clients and logs.

All production changes were made test-first. Gates: **289 passed** (40 live-integration deselected), **pylint 10.00/10**.

## What changed

**Vuln 1 — login-CSRF (MEDIUM)** · `auth_server.py`
A malicious page open during the ~10-min auth window could POST attacker credentials (via a CORS-"simple" `text/plain` body that dodges the preflight) and silently bind the user's MCP to the *attacker's* Monarch account. Now `do_POST`/`do_GET`:
- reject a foreign `Origin` (cross-site),
- require `Content-Type: application/json` (forces a CORS preflight this no-Access-Control-header server fails),
- reject any `Host` that isn't the loopback origin (**H1**, DNS-rebinding).

**H2 — exception reflection (LOW)** · `auth_server.py`
The `/login` and `/mfa` broad-`except` handlers no longer echo raw exception text to the browser (CWE-209); they return a generic message that points the operator to the server logs, where the detail is still recorded.

**H3 — email echo (INFO)** · `server.py`
`check_auth_status` reports only that env credentials are configured, instead of echoing the `MONARCH_EMAIL` address.

**H4 — email in logs (INFO)** · `auth_server.py`
The failed-login log line no longer includes the account email.

**H5 — password lingering in memory (INFO)** · `auth_server.py`
The plaintext password cached on `_AuthState` to span the MFA challenge is scrubbed (`clear_secrets()`) as soon as auth completes and on server shutdown/timeout.

**H6 — debug tool disclosure (INFO)** · `server.py`
`debug_session_loading` no longer returns the token length or a raw traceback; it reports presence only and logs the exception server-side. (Removes the now-unused `traceback` import.)

## Intentionally not changed

**H7** — the `transaction_rules.py` "needs an action" validator's coupling to `extra="allow"` was left as-is by decision: that's documented, tested forward-compat behavior (an unknown/future Monarch action field counts as an action), only INFO-rated, and Monarch validates unknown fields server-side regardless.

## Testing

- New unit tests for each guard (Content-Type/Origin/Host rejection on POST, Host rejection on GET, no-Origin same-host still served), the generic error messages, the log pointer, email-not-logged, `_AuthState.clear_secrets()`, and post-MFA credential scrubbing.
- Updated existing tests that previously asserted the old leaky behavior (raw exception text, token length, echoed email).
- Legit browser flow (navigation GET + same-origin `application/json` fetch) is unchanged; `localhost:<port>` alias still allowed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)