### PR TITLE
chore(ci): bump actions/* off deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/build-mcpb.yml
+++ b/.github/workflows/build-mcpb.yml
@@ -11,12 +11,12 @@ jobs:
   build-mcpb:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -36,7 +36,7 @@ jobs:
         run: mcpb pack . monarch-mcp-${{ inputs.tag }}.mcpb
 
       - name: Upload mcpb as workflow artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mcpb
           path: monarch-mcp-${{ inputs.tag }}.mcpb

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
@@ -27,7 +27,7 @@ jobs:
         run: python -m build
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install dependencies

--- a/.github/workflows/publish-mcp-registry.yml
+++ b/.github/workflows/publish-mcp-registry.yml
@@ -13,12 +13,12 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag }}
 
       - name: Download mcpb artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mcpb
 

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -69,7 +69,7 @@ jobs:
       id-token: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
       id-token: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -66,7 +66,7 @@ jobs:
       id-token: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist/
@@ -87,7 +87,7 @@ jobs:
       contents: write
     steps:
       - name: Download mcpb artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: mcpb
 


### PR DESCRIPTION
## Summary

Clears the Node.js 20 deprecation annotation surfaced on recent CI runs. GitHub forces Node 24 for JavaScript actions starting **2026-06-16** and removes Node 20 from runners on **2026-09-16**. This bumps the first-party `actions/*` that still run on Node 20 to their latest majors.

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-python | v5 | v6 |
| actions/setup-node | v4 | v6 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |

## Compatibility notes

- **checkout / setup-python / setup-node** — drop-in major bumps, exercised by this PR's CI (`ci.yml`).
- **upload-artifact v7 / download-artifact v8** — add direct (unzipped) uploads, ESM packaging, and hash-mismatch-errors-by-default. This repo uploads/downloads **zipped** artifacts with defaults (`archive: true`), which both new majors preserve, so the existing flow is unaffected. These actions run **only in tag-triggered publish workflows**, so they are not exercised by PR CI — compatibility verified from the v7/v8 changelogs.

Third-party actions (`pypa/gh-action-pypi-publish@release/v1`, `softprops/action-gh-release` pinned SHA) were not flagged and are left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)