### PR TITLE
feat(transactions): add clear_notes/clear_goal flags to update_transaction

### DIFF
--- a/.claude/skills/test-monarch-mcp/SKILL.md
+++ b/.claude/skills/test-monarch-mcp/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-monarch-mcp
-description: Systematically test Monarch Money MCP tools in read-only mode (27 tools, 58 tests) or write-enabled mode (all 44 tools, 109 tests). Account-agnostic (discovers IDs at runtime) and self-cleaning (deletes everything it creates in write mode). Batches each phase into a subagent so large tool payloads stay out of the orchestrator's context.
+description: Systematically test Monarch Money MCP tools in read-only mode (27 tools, 58 tests) or write-enabled mode (all 44 tools, 110 tests). Account-agnostic (discovers IDs at runtime) and self-cleaning (deletes everything it creates in write mode). Batches each phase into a subagent so large tool payloads stay out of the orchestrator's context.
 user_invocable: true
 ---
 
@@ -30,7 +30,7 @@ This test suite supports two modes, auto-detected at startup:
 
 - **Read-only mode** (default): Tests 27 read-only tools (58 tests). Write-dependent tests are
   skipped. No data is created, modified, or deleted.
-- **Write-enabled mode** (`--enable-write`): Tests all 44 tools (109 tests). Creates, modifies, and
+- **Write-enabled mode** (`--enable-write`): Tests all 44 tools (110 tests). Creates, modifies, and
   deletes data on your live Monarch account. Self-cleaning.
 
 ---
@@ -180,7 +180,7 @@ The state file is `mcp-test-state.json` in the project root.
   },
   "results": {},
   "summary": {
-    "total": 109,
+    "total": 110,
     "passed": 0,
     "failed": 0,
     "skipped": 0
@@ -189,7 +189,7 @@ The state file is `mcp-test-state.json` in the project root.
 ```
 
 In **read-only mode**, `summary.total` is `58` and `original_values` is omitted (no mutations happen).
-In **write-enabled mode**, `summary.total` is `109`.
+In **write-enabled mode**, `summary.total` is `110`.
 
 ### Update Cadence
 
@@ -240,10 +240,10 @@ approval**:
 
 **Server is running in read-only mode (27 tools).**
 
-I'll run 58 read-only tests and skip 51 write tests. No data will be created, modified, or deleted on
+I'll run 58 read-only tests and skip 52 write tests. No data will be created, modified, or deleted on
 your Monarch account.
 
-To test all 109 tests, disable `monarch-money-read-only` and enable `monarch-money` in `.mcp.json`,
+To test all 110 tests, disable `monarch-money-read-only` and enable `monarch-money` in `.mcp.json`,
 then restart.
 
 **Proceed with read-only tests?**
@@ -256,7 +256,7 @@ then restart.
 
 **WARNING: Server is running in read-write mode (all 44 tools).**
 
-I'll run all 109 tests. This will **create, modify, and delete** data on your **live Monarch Money
+I'll run all 110 tests. This will **create, modify, and delete** data on your **live Monarch Money
 account**:
 
 - It **creates and deletes** transactions, tags, categories, and accounts.
@@ -371,9 +371,11 @@ update_transaction(
 )
 ```
 
-> **Clearing notes:** if `original_values.notes` was null/empty, pass `notes=""`
-> (an empty string) — `update_transaction` treats `null` as "leave unchanged" and
-> only an empty string clears the field. (Same for `goal_id`: pass `""` to unlink.)
+> **Clearing notes:** if `original_values.notes` was null/empty, omit `notes` from the
+> call above and instead pass `clear_notes=true` — `update_transaction` treats `null` as
+> "leave unchanged", and `clear_notes=true` clears the field reliably (some clients cannot
+> transmit the empty string that the legacy `notes=""` path requires). (Same for an unlinked
+> goal: pass `clear_goal=true`.)
 
 #### Step 2: Remove tags from the test transaction
 
@@ -448,7 +450,7 @@ subagent returns.
 ║ Phase 14 — Recurring Merch:   1/1  PASS          ║
 ╠══════════════════════════════════════════════════╣
 ║ TOTAL: 58 passed, 0 failed, 0 skipped           ║
-║ Write tests skipped: 51 (server in read-only)    ║
+║ Write tests skipped: 52 (server in read-only)    ║
 ╚══════════════════════════════════════════════════╝
 ```
 
@@ -463,7 +465,7 @@ subagent returns.
 ║ Phase 3  — Transaction Reads: 9/9  PASS          ║
 ║ Phase 4  — Budgets/Cashflow:  10/10 PASS         ║
 ║ Phase 5  — Tag CRUD:          5/5  PASS          ║
-║ Phase 6  — Transaction CRUD:  15/15 PASS         ║
+║ Phase 6  — Transaction CRUD:  16/16 PASS         ║
 ║ Phase 7  — Tagging:           4/4  PASS          ║
 ║ Phase 8  — Categories:        9/9  PASS          ║
 ║ Phase 9  — Details/Splits:    7/7  PASS          ║
@@ -473,7 +475,7 @@ subagent returns.
 ║ Phase 13 — Transaction Rules: 10/10 PASS         ║
 ║ Phase 14 — Recurring Merch:   5/5  PASS          ║
 ╠══════════════════════════════════════════════════╣
-║ TOTAL: 109 passed, 0 failed, 0 skipped          ║
+║ TOTAL: 110 passed, 0 failed, 0 skipped          ║
 ╚══════════════════════════════════════════════════╝
 ```
 

--- a/.claude/skills/test-monarch-mcp/references/transaction-crud.md
+++ b/.claude/skills/test-monarch-mcp/references/transaction-crud.md
@@ -1,4 +1,4 @@
-# Phase 6 — Transaction CRUD (15 tests)
+# Phase 6 — Transaction CRUD (16 tests)
 
 > **Scope:** Happy create/update/delete paths plus one representative invalid-id error. Adversarial
 > create/update inputs (invalid account/category/date, huge amounts, unicode, 1000-char notes, XSS
@@ -99,7 +99,7 @@ create_transaction(
 
 ---
 
-## Update Tests (10 tests)
+## Update Tests (11 tests)
 
 All update tests use `{test_transaction_id}` from discovery. After all update tests, the original values will be restored during cleanup.
 
@@ -248,7 +248,23 @@ update_transaction(
 
 ---
 
-### Test 6.14 — update_transaction: Invalid transaction_id
+### Test 6.14 — update_transaction: Clear Notes via clear_notes Flag
+
+**Tool call:**
+```
+update_transaction(
+  transaction_id = "{test_transaction_id}",
+  clear_notes    = true
+)
+```
+
+**Expected:** The notes field is cleared (empty). `clear_notes=true` is the client-friendly way to clear notes without passing an empty string.
+
+**Validation:** Response indicates success (not an error). The `notes` field is empty/null. No crash.
+
+---
+
+### Test 6.15 — update_transaction: Invalid transaction_id
 
 **Tool call:**
 ```
@@ -266,7 +282,7 @@ update_transaction(
 
 ## Delete Tests (1 test)
 
-### Test 6.15 — delete_transaction: Happy Path
+### Test 6.16 — delete_transaction: Happy Path
 
 **Prerequisite:** `{created_txn_id}` from test 6.1 must exist.
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ Create a tag called "Business Expenses" in red
 | `get_recurring_transactions` | Get recurring transactions | read |
 | `find_merchant_id_by_name` | Search recent transactions for a merchant and return distinct IDs | read |
 | `create_transaction` | Create new transaction | write |
-| `update_transaction` | Update existing transaction | write |
+| `update_transaction` | Update existing transaction (clear notes with `clear_notes`, unlink goal with `clear_goal`) | write |
 | `delete_transaction` | Delete a transaction | write |
 | `update_transaction_splits` | Create/modify/delete splits | write |
 | `update_recurring_merchant` | Mark/unmark a merchant as recurring, update its frequency/amount, or deactivate it — `is_recurring` is required on every call (requires `--enable-write`) | write |

--- a/src/monarch_mcp/server.py
+++ b/src/monarch_mcp/server.py
@@ -519,25 +519,42 @@ async def update_transaction(  # pylint: disable=too-many-arguments,too-many-pos
     hide_from_reports: Optional[bool] = None,
     needs_review: Optional[bool] = None,
     notes: Optional[str] = None,
+    clear_notes: bool = False,
+    clear_goal: bool = False,
 ) -> str:
     """
     Update an existing transaction in Monarch Money.
 
     Clearing fields: omitting a field (or passing null) leaves it unchanged.
-    To *clear* notes or unlink a goal, pass an empty string ``""`` — passing
-    null does not clear them.
+    To *clear* the notes, pass ``clear_notes=true``; to *unlink* the goal, pass
+    ``clear_goal=true``. (Passing ``notes=""`` / ``goal_id=""`` also clears, but
+    some clients cannot transmit an empty string — prefer the flags.) ``clear_notes``
+    and ``notes`` are mutually exclusive, as are ``clear_goal`` and ``goal_id``.
 
     Args:
         transaction_id: The ID of the transaction to update
         category_id: New category ID
         merchant_name: New merchant name
-        goal_id: Goal ID to associate with the transaction; pass "" to unlink
+        goal_id: Goal ID to associate with the transaction (use clear_goal to unlink)
         amount: New transaction amount
         date: New transaction date in YYYY-MM-DD format
         hide_from_reports: Whether to hide the transaction from reports
         needs_review: Whether the transaction needs review
-        notes: Transaction notes; pass "" to clear existing notes (null = unchanged)
+        notes: New transaction notes (use clear_notes to clear; null = unchanged)
+        clear_notes: Clear the existing notes. Cannot be combined with notes.
+        clear_goal: Unlink the existing goal. Cannot be combined with goal_id.
     """
+
+    if clear_notes and notes:
+        return json.dumps(
+            {"error": "Pass either notes (to set) or clear_notes=true (to clear), not both."},
+            indent=2,
+        )
+    if clear_goal and goal_id:
+        return json.dumps(
+            {"error": "Pass either goal_id (to set) or clear_goal=true (to unlink), not both."},
+            indent=2,
+        )
 
     async def _update_transaction():
         client = await _get_monarch_client()
@@ -548,8 +565,8 @@ async def update_transaction(  # pylint: disable=too-many-arguments,too-many-pos
             update_data["category_id"] = category_id
         if merchant_name is not None:
             update_data["merchant_name"] = merchant_name
-        if goal_id is not None:
-            update_data["goal_id"] = goal_id
+        if clear_goal or goal_id is not None:
+            update_data["goal_id"] = "" if clear_goal else goal_id
         if amount is not None:
             update_data["amount"] = amount
         if date is not None:
@@ -558,8 +575,8 @@ async def update_transaction(  # pylint: disable=too-many-arguments,too-many-pos
             update_data["hide_from_reports"] = hide_from_reports
         if needs_review is not None:
             update_data["needs_review"] = needs_review
-        if notes is not None:
-            update_data["notes"] = notes
+        if clear_notes or notes is not None:
+            update_data["notes"] = "" if clear_notes else notes
 
         return await client.update_transaction(**update_data)
 

--- a/tests/integration/test_transactions_live.py
+++ b/tests/integration/test_transactions_live.py
@@ -118,6 +118,40 @@ async def test_update_transaction_adversarial_input_is_graceful(
         )
 
 
+# ── robustness: clear_notes flag actually clears on the live API ───────
+
+async def test_update_transaction_clear_notes_flag_clears_live(
+    live_write_client, call_json, extract_id, checking_account_id, category_id
+):
+    # The clear_notes flag exists because some clients can't transmit notes="".
+    # Verify it really empties the note on Monarch's side (not just locally).
+    txn_id, result = await _create_txn(
+        live_write_client, call_json, extract_id, checking_account_id, category_id,
+        notes="MCP-Test-note-to-clear",
+    )
+    assert txn_id, f"setup failed to create throwaway txn: {result}"
+    try:
+        before = await call_json(
+            live_write_client, "get_transaction_details", {"transaction_id": txn_id}
+        )
+        assert "MCP-Test-note-to-clear" in json.dumps(before)
+
+        await call_json(
+            live_write_client, "update_transaction",
+            {"transaction_id": txn_id, "clear_notes": True},
+        )
+
+        after = await call_json(
+            live_write_client, "get_transaction_details", {"transaction_id": txn_id}
+        )
+        assert "MCP-Test-note-to-clear" not in json.dumps(after), \
+            f"clear_notes did not clear the note: {json.dumps(after)[:300]}"
+    finally:
+        await live_write_client.call_tool(
+            "delete_transaction", {"transaction_id": txn_id}
+        )
+
+
 # ── live error path: server-side invalid date on create ────────────────
 
 async def test_create_transaction_invalid_date_is_graceful(

--- a/tests/test_server_edge_cases.py
+++ b/tests/test_server_edge_cases.py
@@ -150,6 +150,34 @@ async def test_update_transaction_goal_id(mcp_write_client, mock_monarch_client)
     assert call_kwargs["goal_id"] == "goal-42"
 
 
+async def test_update_transaction_clear_goal_flag(mcp_write_client, mock_monarch_client):
+    # clear_goal=true unlinks the goal via the client-friendly flag, forwarded as goal_id="".
+    mock_monarch_client.update_transaction.return_value = {"ok": True}
+
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "update_transaction", {"transaction_id": "txn-1", "clear_goal": True}
+        )).content[0].text
+    )
+
+    assert result["ok"] is True
+    call_kwargs = mock_monarch_client.update_transaction.call_args[1]
+    assert call_kwargs["goal_id"] == ""
+
+
+async def test_update_transaction_clear_goal_conflict(mcp_write_client, mock_monarch_client):
+    # Linking and unlinking a goal at once is contradictory — reject loudly.
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "update_transaction",
+            {"transaction_id": "txn-1", "goal_id": "goal-42", "clear_goal": True},
+        )).content[0].text
+    )
+
+    assert "error" in result
+    mock_monarch_client.update_transaction.assert_not_called()
+
+
 # ===================================================================
 # refresh_accounts — empty account list
 # ===================================================================

--- a/tests/test_transaction_crud.py
+++ b/tests/test_transaction_crud.py
@@ -252,7 +252,7 @@ async def test_create_default_update_balance(mcp_write_client, mock_monarch_clie
 
 
 # ===================================================================
-# UPDATE (14 tests)
+# UPDATE (17 tests)
 # ===================================================================
 
 
@@ -279,6 +279,53 @@ async def test_update_clear_notes_with_empty_string(mcp_write_client, mock_monar
     result = json.loads(
         (await mcp_write_client.call_tool(
             "update_transaction", {"transaction_id": "txn-1", "notes": ""}
+        )).content[0].text
+    )
+
+    assert result["notes"] == ""
+    call_kwargs = mock_monarch_client.update_transaction.call_args[1]
+    assert call_kwargs["notes"] == ""
+
+
+async def test_update_clear_notes_with_flag(mcp_write_client, mock_monarch_client):
+    # clear_notes=true is the client-friendly way to clear notes (no empty string
+    # needed): the flag must be forwarded to the underlying API as notes="".
+    mock_monarch_client.update_transaction.return_value = {"id": "txn-1", "notes": ""}
+
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "update_transaction", {"transaction_id": "txn-1", "clear_notes": True}
+        )).content[0].text
+    )
+
+    assert result["notes"] == ""
+    call_kwargs = mock_monarch_client.update_transaction.call_args[1]
+    assert call_kwargs["notes"] == ""
+
+
+async def test_update_clear_notes_flag_conflict(mcp_write_client, mock_monarch_client):
+    # Setting notes and clearing them at once is contradictory — reject loudly
+    # rather than silently picking one.
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "update_transaction",
+            {"transaction_id": "txn-1", "notes": "keep", "clear_notes": True},
+        )).content[0].text
+    )
+
+    assert "error" in result
+    mock_monarch_client.update_transaction.assert_not_called()
+
+
+async def test_update_clear_notes_flag_with_empty_string_ok(mcp_write_client, mock_monarch_client):
+    # clear_notes=true alongside notes="" is redundant agreement (both mean "clear"),
+    # not a conflict — it must succeed and clear the notes.
+    mock_monarch_client.update_transaction.return_value = {"id": "txn-1", "notes": ""}
+
+    result = json.loads(
+        (await mcp_write_client.call_tool(
+            "update_transaction",
+            {"transaction_id": "txn-1", "notes": "", "clear_notes": True},
         )).content[0].text
     )
 


### PR DESCRIPTION
## Summary

Adds explicit `clear_notes` / `clear_goal` boolean flags to the `update_transaction` MCP tool, giving every client a reliable way to clear a transaction's notes or unlink its goal.

## Why

Clearing notes (or unlinking a goal) previously required passing an **empty string** (`notes=""` / `goal_id=""`); `null` means "leave unchanged". Some MCP clients cannot reliably transmit an empty-string argument — the call can arrive at the server with an empty parameter object — making the documented clear-path unreachable in practice. This surfaced concretely during a `test-monarch-mcp` cleanup run, where reverting a transaction's notes via `notes=""` failed and left a stray note behind.

Non-empty argument values (booleans) transmit reliably, so a boolean flag sidesteps the problem deterministically.

## What changed

- **`src/monarch_mcp/server.py`** — new `clear_notes` / `clear_goal` params, docstring rewrite, mutual-exclusion validation (returns `{"error": ...}` when a clear flag is combined with its value counterpart), and mapping of the flags to the empty-string clear. The legacy `notes=""` / `goal_id=""` path still works for clients that can send it.
- **Unit tests** — clear-via-flag, conflict rejection, and redundant-agreement-OK cases (`tests/test_transaction_crud.py`, `tests/test_server_edge_cases.py`).
- **Live e2e** — `tests/integration/test_transactions_live.py` verifies `clear_notes` actually empties the note on the real Monarch API (self-cleaning).
- **`test-monarch-mcp` skill** — new happy-path test 6.14; cleanup now uses `clear_notes=true`; test counts bumped 109 → 110.
- **`README.md`** — documents the flags.

## Verification

- `python -m pytest tests/` → **294 passed**.
- `python -m pylint src/monarch_mcp/` → **10.00/10**.
- Live integration test (`-k clear`, `MONARCH_LIVE_TESTS=1`) → **passed** against the real API.
- Full agent-driven `test-monarch-mcp` write-mode run → **110/110 passed**, including the new clear_notes test and a cleanup that reverted notes cleanly with no residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)